### PR TITLE
Fix stage transition bug in scroll handler

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,8 +9,9 @@ window.addEventListener('scroll', () => {
 	} else if (y < vh * 1.5) {
 		container.classList.add('stage1');
 		container.classList.remove('stage2');
-	} else {
-		container.classList.add('stage2');
-	}
+        } else {
+                container.classList.remove('stage1');
+                container.classList.add('stage2');
+        }
 });
 


### PR DESCRIPTION
## Summary
- ensure `stage1` class is removed when activating `stage2`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892eea99f708327a43dfcde148dd49c