### PR TITLE
fix: inline final message image alt attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 	</div>
 	<div class="final-message">
 		<h1>저희 결혼합니다 💍</h1>
-		<img src="https://www.iwedding.co.kr/center/iweddingb/product/800_17588_1730685980_90793400_3232256098.jpg" alt="사진" />
+    <img src="https://www.iwedding.co.kr/center/iweddingb/product/800_17588_1730685980_90793400_3232256098.jpg" alt="사진" />
 	</div>
 </section>
 


### PR DESCRIPTION
## Summary
- keep final-message image `alt` text on a single line to avoid newline after `alt=`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68931ab69ba08327b080ee2b0ab787e6