### PR TITLE
Fix stage class management on scroll

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,11 +6,12 @@ window.addEventListener('scroll', () => {
 
 	if (y < vh * 0.5) {
 		container.classList.remove('stage1', 'stage2');
-	} else if (y < vh * 1.5) {
-		container.classList.add('stage1');
-		container.classList.remove('stage2');
-	} else {
-		container.classList.add('stage2');
-	}
+        } else if (y < vh * 1.5) {
+                container.classList.add('stage1');
+                container.classList.remove('stage2');
+        } else {
+                container.classList.add('stage2');
+                container.classList.remove('stage1');
+        }
 });
 


### PR DESCRIPTION
## Summary
- ensure stage1 is removed when entering stage2 scroll range

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68931ab932c08327bd59d993b3e23424