### PR TITLE
Fix stage2 class toggling

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,8 +9,9 @@ window.addEventListener('scroll', () => {
 	} else if (y < vh * 1.5) {
 		container.classList.add('stage1');
 		container.classList.remove('stage2');
-	} else {
-		container.classList.add('stage2');
-	}
+        } else {
+                container.classList.add('stage2');
+                container.classList.remove('stage1');
+        }
 });
 


### PR DESCRIPTION
## Summary
- Ensure `stage1` is removed when activating `stage2` in scroll handler

## Testing
- `node` script using jsdom to simulate scroll events

------
https://chatgpt.com/codex/tasks/task_e_6893eac3add083279c1e939f02b47f81