### PR TITLE
Refine invitation styling and countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         <div class="content">
                 <h2>이성우 & 임상영</h2>
                 <p>2026년 5월 17일 (일) 오전 10시 30분</p>
-                <p>서울 더라빌 그랜드홀</p>
+               <p>메리빌리아더프레스티지</p>
         </div>
 	<div class="final-message">
 		<h1>저희 결혼합니다 💍</h1>
@@ -71,7 +71,7 @@
         <button id="share-kakao">카카오톡 공유</button>
 </section>
 
-<script src="https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=yp02tw24ay"></script>
+<script src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpClientId=yp02tw24ay"></script>
 <script>
         const position = new naver.maps.LatLng(37.2627302, 126.9966484);
         const map = new naver.maps.Map('map', {

--- a/script.js
+++ b/script.js
@@ -52,12 +52,17 @@ document.addEventListener('DOMContentLoaded', () => {
                                 countdownEl.textContent = '예식이 시작되었습니다!';
                                 return;
                         }
-                        const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-                        const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
-                        const minutes = Math.floor((diff / (1000 * 60)) % 60);
-                        const seconds = Math.floor((diff / 1000) % 60);
-                        countdownEl.textContent = `${days}일 ${hours}시간 ${minutes}분 ${seconds}초 남았습니다`;
-                };
+                       const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+                       const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+                       const minutes = Math.floor((diff / (1000 * 60)) % 60);
+                       const seconds = Math.floor((diff / 1000) % 60);
+                       const parts = [];
+                       if (days > 0) parts.push(`${days}일`);
+                       if (hours > 0) parts.push(`${hours}시간`);
+                       if (minutes > 0) parts.push(`${minutes}분`);
+                       if (seconds > 0) parts.push(`${seconds}초`);
+                       countdownEl.textContent = parts.length ? `${parts.join(' ')} 남았습니다` : '';
+               };
                 updateCountdown();
                 setInterval(updateCountdown, 1000);
         }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 body {
     margin: 0;
     font-family: 'Nanum Myeongjo', serif;
-    background: linear-gradient(135deg, #fff1f5, #ffe6e8);
+    background: linear-gradient(135deg, #fffaf0, #ffe4e1, #fff0f5);
     color: #444;
 }
 
@@ -43,6 +43,8 @@ body {
     padding: 32px 24px;
     border-radius: 20px;
     box-shadow: 0 6px 25px rgba(0, 0, 0, 0.1);
+    max-width: 90%;
+    word-break: keep-all;
 }
 
 /* 2단계: 결혼합니다 */
@@ -54,6 +56,8 @@ body {
     padding: 32px 24px;
     border-radius: 20px;
     box-shadow: 0 6px 25px rgba(0, 0, 0, 0.1);
+    max-width: 90%;
+    word-break: keep-all;
 }
 
 .container.stage1 .lid-icon {
@@ -78,7 +82,8 @@ body {
 }
 
 .final-message img {
-    width: 260px;
+    width: 100%;
+    max-width: 260px;
     border-radius: 20px;
     box-shadow: 0 6px 20px rgba(0,0,0,0.2);
     margin-top: 16px;
@@ -94,6 +99,11 @@ body {
 .content p {
     font-size: 1.1rem;
     line-height: 1.6;
+    word-break: keep-all;
+}
+
+.directions-section p {
+    word-break: keep-all;
 }
 
 .final-message h1 {
@@ -150,14 +160,18 @@ body {
 }
 
 /* 추가 섹션 스타일 */
- .map-section,
- .calendar-section,
- .countdown-section,
- .directions-section,
- .share-section {
+.map-section,
+.calendar-section,
+.countdown-section,
+.directions-section,
+.share-section {
     padding: 40px 20px;
     text-align: center;
-    background: rgba(255, 255, 255, 0.8);
+    background: rgba(255, 255, 255, 0.9);
+    margin: 20px auto;
+    max-width: 600px;
+    border-radius: 16px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.05);
 }
 
 .map-container {
@@ -192,8 +206,15 @@ body {
     margin: 0 10px;
     padding: 10px 20px;
     border: none;
-    border-radius: 5px;
-    background: #b75d69;
+    border-radius: 30px;
+    background: linear-gradient(45deg, #ff9a9e, #fad0c4);
     color: #fff;
     font-size: 1rem;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    cursor: pointer;
+    transition: transform 0.2s ease;
+}
+
+.share-section button:hover {
+    transform: translateY(-2px);
 }


### PR DESCRIPTION
## Summary
- update venue and map API URL
- brighten layout with clearer section cards and styled share buttons
- hide zero units in event countdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893ffe3ce6c8327944e5d8ce88f8c37