### PR TITLE
feat: enhance directions and sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,15 +65,10 @@
 
     <section class="directions-section fade-section">
       <h3>오시는 방법</h3>
-      <h4>대중교통</h4>
-      <p>
-        지하철 1호선 수원역 9번 출구에서 버스 7번 환승 후
-        메리빌리아더프레스티지 하차
-      </p>
       <h4>도보</h4>
-      <p>수원역 9번 출구에서 도보 15분</p>
+      <p>수원역 9번 출구에서 도보 10분</p>
       <h4>주차</h4>
-      <p>예식장 지하 주차장 이용 가능 (3시간 무료)</p>
+      <p>예식장 지하 주차장 이용 가능 (2시간 무료)</p>
     </section>
 
     <section class="calendar-section fade-section">
@@ -104,6 +99,8 @@
       <button id="share-url">URL 공유</button>
       <button id="share-kakao">카카오톡 공유</button>
     </section>
+
+    <div id="copy-toast" class="copy-toast"></div>
 
     <footer class="footer">© 2024 Wedding Invitation</footer>
 

--- a/script.js
+++ b/script.js
@@ -50,10 +50,13 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   const copyUrlBtn = document.getElementById("copy-url");
-  if (copyUrlBtn) {
+  const copyToast = document.getElementById("copy-toast");
+  if (copyUrlBtn && copyToast) {
     copyUrlBtn.addEventListener("click", async () => {
       await navigator.clipboard.writeText(window.location.href);
-      alert("URL이 복사되었습니다");
+      copyToast.textContent = "URL이 복사되었습니다";
+      copyToast.classList.add("show");
+      setTimeout(() => copyToast.classList.remove("show"), 2000);
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -51,6 +51,11 @@ body {
   text-align: center;
 }
 
+.directions-section,
+.countdown-section {
+  background: #f9f9f9;
+}
+
 .map-container {
   width: 100%;
   height: 300px;
@@ -206,6 +211,24 @@ body {
   background: #f5f5f5;
 }
 
+.copy-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 20px;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 20px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.copy-toast.show {
+  opacity: 1;
+}
+
 .footer {
   text-align: center;
   padding: 20px;
@@ -226,7 +249,7 @@ body {
 .fade-section {
   opacity: 0;
   transform: translateY(20px);
-  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+  transition: opacity 1s ease-out, transform 1s ease-out;
 }
 
 .fade-section.visible {


### PR DESCRIPTION
## Summary
- match "오시는 방법" and "남은 시간" sections with info background
- slow fade-in animation for clearer scrolling effect
- toast-style copy notification and updated travel details

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68940f23aa7883279c8eb29a3d29f6d3