### PR TITLE
Add metadata for link previews and update sharing details

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,31 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>모바일 청첩장</title>
+    <meta
+      name="description"
+      content="이성우 & 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="모바일 청첩장" />
+    <meta
+      property="og:description"
+      content="이성우 & 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지"
+    />
+    <meta
+      property="og:image"
+      content="https://www.iwedding.co.kr/center/iweddingb/product/800_17588_1730685980_90793400_3232256098.jpg"
+    />
+    <meta property="og:locale" content="ko_KR" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="모바일 청첩장" />
+    <meta
+      name="twitter:description"
+      content="이성우 & 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지"
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.iwedding.co.kr/center/iweddingb/product/800_17588_1730685980_90793400_3232256098.jpg"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/script.js
+++ b/script.js
@@ -65,7 +65,11 @@ document.addEventListener("DOMContentLoaded", () => {
     shareUrlBtn.addEventListener("click", async () => {
       if (navigator.share) {
         try {
-          await navigator.share({ title: "청첩장", url: window.location.href });
+          await navigator.share({
+            title: "이성우♥임상영 청첩장",
+            text: "2026년 5월 17일 메리빌리아더프레스티지",
+            url: window.location.href,
+          });
         } catch (e) {
           console.log(e);
         }
@@ -84,8 +88,8 @@ document.addEventListener("DOMContentLoaded", () => {
           objectType: "feed",
           content: {
             title: "이성우♥임상영 청첩장",
-            description: "2026년 5월 17일 일요일 오전 10시 30분",
-            imageUrl: "https://via.placeholder.com/300",
+            description: "2026년 5월 17일 일요일 오전 10시 30분 메리빌리아더프레스티지",
+            imageUrl: "https://www.iwedding.co.kr/center/iweddingb/product/800_17588_1730685980_90793400_3232256098.jpg",
             link: {
               mobileWebUrl: window.location.href,
               webUrl: window.location.href,


### PR DESCRIPTION
## Summary
- add Open Graph/Twitter metadata for accurate link previews
- improve Web Share API usage with title, text, and new image
- update Kakao share content to include wedding details and hero image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894110cf68c832783c3ca6e72e1b66e