### PR TITLE
chore: refine map info window and font

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Nanum+Myeongjo:wght@400;700&family=Nanum+Pen+Script&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="style.css" />
@@ -141,7 +141,8 @@
       });
       const marker = new naver.maps.Marker({ position, map });
       const infoWindow = new naver.maps.InfoWindow({
-        content: '<div style="padding:5px;">메리빌리아더프레스티지</div>',
+        content:
+          '<div style="padding:5px; word-break:break-all;">메리빌리아더프레스티지</div>',
       });
       infoWindow.open(map, marker);
     </script>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  font-family: "Nanum Myeongjo", serif;
+  font-family: "Noto Sans KR", sans-serif;
   background: #ffffff;
   color: #333;
   word-break: keep-all;
@@ -18,7 +18,8 @@ body {
 }
 
 .hero-content h1 {
-  font-family: "Nanum Pen Script", cursive;
+  font-family: "Noto Sans KR", sans-serif;
+  font-weight: 700;
   font-size: 3rem;
   margin: 0 0 16px;
 }


### PR DESCRIPTION
## Summary
- prevent Naver Map info window text from overflowing on mobile
- switch site fonts to minimal Noto Sans KR for cleaner look

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68941ac255148327a7d37763902830f3