### PR TITLE
style: refresh typography and countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="style.css" />

--- a/script.js
+++ b/script.js
@@ -25,25 +25,29 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const countdownEl = document.getElementById("countdown");
   if (countdownEl) {
+    countdownEl.innerHTML = `
+      <div class="countdown-item"><span class="countdown-num" id="cd-days">00</span><span class="countdown-label">DAYS</span></div>
+      <div class="countdown-item"><span class="countdown-num" id="cd-hours">00</span><span class="countdown-label">HRS</span></div>
+      <div class="countdown-item"><span class="countdown-num" id="cd-minutes">00</span><span class="countdown-label">MIN</span></div>
+      <div class="countdown-item"><span class="countdown-num" id="cd-seconds">00</span><span class="countdown-label">SEC</span></div>
+    `;
+    const daysEl = document.getElementById("cd-days");
+    const hoursEl = document.getElementById("cd-hours");
+    const minutesEl = document.getElementById("cd-minutes");
+    const secondsEl = document.getElementById("cd-seconds");
+
     const updateCountdown = () => {
       const now = new Date();
-      const diff = eventDate - now;
-      if (diff <= 0) {
-        countdownEl.textContent = "예식이 시작되었습니다!";
-        return;
-      }
+      let diff = eventDate - now;
+      if (diff < 0) diff = 0;
       const days = Math.floor(diff / (1000 * 60 * 60 * 24));
       const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
       const minutes = Math.floor((diff / (1000 * 60)) % 60);
       const seconds = Math.floor((diff / 1000) % 60);
-      const parts = [];
-      if (days > 0) parts.push(`${days}일`);
-      if (hours > 0) parts.push(`${hours}시간`);
-      if (minutes > 0) parts.push(`${minutes}분`);
-      if (seconds > 0) parts.push(`${seconds}초`);
-      countdownEl.textContent = parts.length
-        ? `${parts.join(" ")} 남았습니다`
-        : "";
+      daysEl.textContent = String(days).padStart(2, "0");
+      hoursEl.textContent = String(hours).padStart(2, "0");
+      minutesEl.textContent = String(minutes).padStart(2, "0");
+      secondsEl.textContent = String(seconds).padStart(2, "0");
     };
     updateCountdown();
     setInterval(updateCountdown, 1000);

--- a/style.css
+++ b/style.css
@@ -1,9 +1,20 @@
 body {
   margin: 0;
   font-family: "Noto Sans KR", sans-serif;
+  font-weight: 300;
   background: #ffffff;
   color: #333;
   word-break: keep-all;
+  letter-spacing: -0.02em;
+  line-height: 1.8;
+}
+
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 400;
 }
 
 .hero-section {
@@ -19,7 +30,7 @@ body {
 
 .hero-content h1 {
   font-family: "Noto Sans KR", sans-serif;
-  font-weight: 700;
+  font-weight: 300;
   font-size: 3rem;
   margin: 0 0 16px;
 }
@@ -33,7 +44,7 @@ body {
 .invitation-section {
   padding: 60px 20px;
   text-align: center;
-  line-height: 1.6;
+  line-height: 1.8;
 }
 
 .info-section {
@@ -96,6 +107,16 @@ body {
   padding: 4px 0;
 }
 
+.calendar-container th:first-child,
+.calendar-container td:first-child {
+  color: #d9534f;
+}
+
+.calendar-container th:last-child,
+.calendar-container td:last-child {
+  color: #337ab7;
+}
+
 
 .calendar-container .event-day {
   display: inline-flex;
@@ -109,8 +130,26 @@ body {
 }
 
 #countdown {
-  font-size: 1.2rem;
+  display: flex;
+  justify-content: center;
+  gap: 12px;
   margin-top: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.countdown-item {
+  text-align: center;
+}
+
+.countdown-num {
+  display: block;
+  font-size: 2rem;
+  min-width: 2ch;
+}
+
+.countdown-label {
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
 }
 
 .gallery-grid {


### PR DESCRIPTION
## Summary
- use lighter Noto Sans KR with tighter tracking and wider leading
- highlight weekends in calendar with red Sundays and blue Saturdays
- redesign countdown timer with fixed-width digits and labels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68941f2d094c8327b7735c2615cee4ab