### PR TITLE
Refine wedding invitation details

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,13 +6,13 @@
     <title>모바일 청첩장</title>
     <meta
       name="description"
-      content="이성우 & 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지"
+      content="이성우 ♥ 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지 가든홀"
     />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="모바일 청첩장" />
     <meta
       property="og:description"
-      content="이성우 & 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지"
+      content="이성우 ♥ 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지 가든홀"
     />
     <meta
       property="og:image"
@@ -23,7 +23,7 @@
     <meta name="twitter:title" content="모바일 청첩장" />
     <meta
       name="twitter:description"
-      content="이성우 & 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지"
+      content="이성우 ♥ 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지 가든홀"
     />
     <meta
       name="twitter:image"
@@ -40,9 +40,9 @@
   <body>
     <section class="hero-section">
       <div class="hero-content">
-        <h1>이성우 & 임상영</h1>
+        <h1>이성우 ♥ 임상영</h1>
         <p class="date">2026년 5월 17일 (일) 오전 10시 30분</p>
-        <p class="location">메리빌리아더프레스티지</p>
+        <p class="location">메리빌리아더프레스티지 가든홀</p>
       </div>
     </section>
 
@@ -63,7 +63,7 @@
     <section class="info-section fade-section">
       <h3>예식 안내</h3>
       <p>2026년 5월 17일 (일) 오전 10시 30분</p>
-      <p>메리빌리아더프레스티지</p>
+      <p>메리빌리아더프레스티지 가든홀</p>
     </section>
 
     <!-- 오시는 길 -->
@@ -93,7 +93,7 @@
       <h4>도보</h4>
       <p>수원역 9번 출구에서 도보 10분</p>
       <h4>주차</h4>
-      <p>예식장 지하 주차장 이용 가능 (2시간 무료)</p>
+      <p>예식장 내 주차장 이용 가능 (2시간 무료)</p>
     </section>
 
     <section class="calendar-section fade-section">
@@ -142,7 +142,7 @@
       const marker = new naver.maps.Marker({ position, map });
       const infoWindow = new naver.maps.InfoWindow({
         content:
-          '<div style="padding:5px; word-break:break-all;">메리빌리아더프레스티지</div>',
+          '<div style="padding:5px; word-break:break-all;">메리빌리아더프레스티지 가든홀</div>',
       });
       infoWindow.open(map, marker);
     </script>

--- a/script.js
+++ b/script.js
@@ -8,7 +8,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const month = eventDate.getMonth();
     const firstDay = new Date(year, month, 1).getDay();
     const lastDate = new Date(year, month + 1, 0).getDate();
-    let html = `<div class="calendar-header">${year}년 ${month + 1}월</div>`;
+    let html = `<div class="calendar-header">${year}. ${String(month + 1).padStart(2, "0")}</div>`;
     html += "<table><thead><tr>";
     const days = ["일", "월", "화", "수", "목", "금", "토"];
     html += days.map((d) => `<th>${d}</th>`).join("");
@@ -70,8 +70,8 @@ document.addEventListener("DOMContentLoaded", () => {
       if (navigator.share) {
         try {
           await navigator.share({
-            title: "이성우♥임상영 청첩장",
-            text: "2026년 5월 17일 메리빌리아더프레스티지",
+            title: "이성우 ♥ 임상영 청첩장",
+            text: "2026년 5월 17일 메리빌리아더프레스티지 가든홀",
             url: window.location.href,
           });
         } catch (e) {
@@ -91,8 +91,8 @@ document.addEventListener("DOMContentLoaded", () => {
         Kakao.Share.sendDefault({
           objectType: "feed",
           content: {
-            title: "이성우♥임상영 청첩장",
-            description: "2026년 5월 17일 일요일 오전 10시 30분 메리빌리아더프레스티지",
+            title: "이성우 ♥ 임상영 청첩장",
+            description: "2026년 5월 17일 일요일 오전 10시 30분 메리빌리아더프레스티지 가든홀",
             imageUrl: "https://www.iwedding.co.kr/center/iweddingb/product/800_17588_1730685980_90793400_3232256098.jpg",
             link: {
               mobileWebUrl: window.location.href,

--- a/style.css
+++ b/style.css
@@ -95,6 +95,12 @@ h6 {
   background: #f5f5f5;
 }
 
+.calendar-header {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
 .calendar-container table {
   width: 100%;
   border-collapse: collapse;
@@ -112,8 +118,8 @@ h6 {
   color: #d9534f;
 }
 
-.calendar-container th:last-child,
-.calendar-container td:last-child {
+.calendar-container th:nth-child(7),
+.calendar-container td:nth-child(7) {
   color: #337ab7;
 }
 

--- a/tests/hero.test.js
+++ b/tests/hero.test.js
@@ -7,5 +7,5 @@ test("index.html includes redesigned hero section", () => {
     "utf8",
   );
   expect(html).toMatch(/class="hero-section"/);
-  expect(html).toMatch(/이성우 & 임상영/);
+  expect(html).toMatch(/이성우 ♥ 임상영/);
 });


### PR DESCRIPTION
## Summary
- Replace the ampersand in couple names with a heart and mention Garden Hall in venue details
- Update parking instructions to point to the on-site parking
- Restyle the calendar header and ensure Sundays like the 31st stay red

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894227ee5948327a468bf754295a4a0