### PR TITLE
Separate wedding details, update map/share icons, and centralize API keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,15 +6,13 @@
     <title>모바일 청첩장</title>
     <meta
       name="description"
-      content="이성우 ♥ 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지
-가든홀"
+      content="이성우 ♥ 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지 가든홀"
     />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="모바일 청첩장" />
     <meta
       property="og:description"
-      content="이성우 ♥ 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지
-가든홀"
+      content="이성우 ♥ 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지 가든홀"
     />
     <meta
       property="og:image"
@@ -25,8 +23,7 @@
     <meta name="twitter:title" content="모바일 청첩장" />
     <meta
       name="twitter:description"
-      content="이성우 ♥ 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지
-가든홀"
+      content="이성우 ♥ 임상영의 모바일 청첩장 - 2026년 5월 17일 메리빌리아더프레스티지 가든홀"
     />
     <meta
       name="twitter:image"
@@ -43,12 +40,16 @@
   <body>
     <section class="hero-section">
       <div class="hero-content">
-        <h1>이성우 ♥ 임상영</h1>
+        <div class="hero-names">
+          <p class="groom">이성우</p>
+          <p class="bride">임상영</p>
+        </div>
         <div class="hero-datetime">
           <p class="date">2026년 5월 17일 (일)</p>
           <p class="time">오전 10시 30분</p>
         </div>
-        <p class="location">메리빌리아더프레스티지<br />가든홀</p>
+        <p class="location">메리빌리아더프레스티지</p>
+        <p class="hall">가든홀</p>
       </div>
     </section>
 
@@ -66,8 +67,12 @@
 
     <section class="info-section fade-section">
       <h3>예식 안내</h3>
-      <p>2026년 5월 17일 (일) 오전 10시 30분</p>
-      <p>메리빌리아더프레스티지<br />가든홀</p>
+      <p class="groom">이성우</p>
+      <p class="bride">임상영</p>
+      <p class="date">2026년 5월 17일 (일)</p>
+      <p class="time">오전 10시 30분</p>
+      <p class="location">메리빌리아더프레스티지</p>
+      <p class="hall">가든홀</p>
     </section>
 
     <!-- 오시는 길 -->
@@ -81,7 +86,7 @@
           target="_blank"
           rel="noopener"
           ><img
-            src="https://img.icons8.com/color/48/naver.png"
+            src="https://play-lh.googleusercontent.com/iqe1hFI03eD6nW3S8fxK_MDvNC8tDtod_gnhF9e8XN-IPmLXJvZVJLm-bQ4U5mKAVK0"
             alt="네이버맵 아이콘"
             class="btn-icon"
           />네이버 지도</a
@@ -92,7 +97,7 @@
           target="_blank"
           rel="noopener"
           ><img
-            src="https://img.icons8.com/color/48/kakaomap.png"
+            src="https://play-lh.googleusercontent.com/pPTTNz433EYFurg2j__bFU5ONdMoU_bs_-yS2JLZriua3iHrksGP6XBPF5VtDPlpGcW4"
             alt="카카오맵 아이콘"
             class="btn-icon"
           />카카오 지도</a
@@ -102,10 +107,18 @@
 
     <section class="directions-section fade-section">
       <h3>오시는 방법</h3>
-      <h4>도보</h4>
-      <p>수원역 9번 출구에서 도보 10분</p>
-      <h4>주차</h4>
-      <p>예식장 내 주차장 이용 가능 (2시간 무료)</p>
+      <div class="direction-item walk">
+        <h4 class="method">도보</h4>
+        <p class="detail">수원역 9번 출구에서 도보 10분</p>
+      </div>
+      <div class="direction-item transit">
+        <h4 class="method">대중교통</h4>
+        <p class="detail"></p>
+      </div>
+      <div class="direction-item parking">
+        <h4 class="method">주차</h4>
+        <p class="detail">예식장 내 주차장 이용 가능 (2시간 무료)</p>
+      </div>
     </section>
 
     <section class="calendar-section fade-section">
@@ -135,21 +148,21 @@
       <button id="copy-url">
         <img
           src="https://img.icons8.com/ios-glyphs/30/copy.png"
-          alt=""
+          alt="복사 아이콘"
           class="btn-icon"
         />URL 복사
       </button>
       <button id="share-url">
         <img
           src="https://img.icons8.com/ios-glyphs/30/share.png"
-          alt=""
+          alt="공유 아이콘"
           class="btn-icon"
         />URL 공유
       </button>
       <button id="share-kakao">
         <img
-          src="https://img.icons8.com/color/48/kakao-talk--v1.png"
-          alt=""
+          src="https://play-lh.googleusercontent.com/Ob9Ys8yKMeyKzZvl3cB9JNSTui1lJwjSKD60IVYnlvU2DsahysGENJE-txiRIW9_72Vd"
+          alt="카카오톡 아이콘"
           class="btn-icon"
         />카카오톡 공유
       </button>
@@ -158,24 +171,6 @@
     <div id="copy-toast" class="copy-toast"></div>
 
     <footer class="footer">© 2024 Wedding Invitation</footer>
-
-    <script
-      type="text/javascript"
-      src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=yp02tw24ay"
-    ></script>
-    <script>
-      const position = new naver.maps.LatLng(37.2627302, 126.9966484);
-      const map = new naver.maps.Map("map", {
-        center: position,
-        zoom: 15,
-      });
-      const marker = new naver.maps.Marker({ position, map });
-      const infoWindow = new naver.maps.InfoWindow({
-        content:
-          '<div style="padding:5px; word-break:break-all;">메리빌리아더프레스티지<br/>가든홀</div>',
-      });
-      infoWindow.open(map, marker);
-    </script>
 
     <script
       src="https://t1.kakaocdn.net/kakao_js_sdk/2.4.0/kakao.min.js"

--- a/script.js
+++ b/script.js
@@ -1,6 +1,82 @@
 // 추가 기능: 달력, 남은 시간, 공유 버튼
-document.addEventListener("DOMContentLoaded", () => {
+const GROOM_NAME = "이성우";
+const BRIDE_NAME = "임상영";
+const EVENT_DATE_TEXT = "2026년 5월 17일 (일)";
+const EVENT_TIME_TEXT = "오전 10시 30분";
+const VENUE_LOCATION = "메리빌리아더프레스티지";
+const VENUE_HALL = "가든홀";
+const VENUE_LAT = 37.2627302;
+const VENUE_LNG = 126.9966484;
+const WALK_INFO = "수원역 9번 출구에서 도보 10분";
+const TRANSIT_INFO = "";
+const PARKING_INFO = "예식장 내 주차장 이용 가능 (2시간 무료)";
+const NAVER_MAP_API_KEY = "yp02tw24ay";
+const KAKAO_API_KEY = "ad9882a7a0abfaffbde309e333d2e43e";
+
+const loadScript = (src) =>
+  new Promise((resolve, reject) => {
+    const s = document.createElement("script");
+    s.src = src;
+    s.onload = resolve;
+    s.onerror = reject;
+    document.head.appendChild(s);
+  });
+
+document.addEventListener("DOMContentLoaded", async () => {
   const eventDate = new Date(2026, 4, 17, 10, 30);
+
+  document.querySelectorAll(".groom").forEach((el) => (el.textContent = GROOM_NAME));
+  document.querySelectorAll(".bride").forEach((el) => (el.textContent = BRIDE_NAME));
+  document.querySelectorAll(".date").forEach((el) => (el.textContent = EVENT_DATE_TEXT));
+  document.querySelectorAll(".time").forEach((el) => (el.textContent = EVENT_TIME_TEXT));
+  document
+    .querySelectorAll(".location")
+    .forEach((el) => (el.textContent = VENUE_LOCATION));
+  document
+    .querySelectorAll(".hall")
+    .forEach((el) => (el.textContent = VENUE_HALL));
+  const setDirectionInfo = (cls, info) => {
+    const item = document.querySelector(`.directions-section .${cls}`);
+    if (!item) return;
+    const detailEl = item.querySelector(".detail");
+    if (info) {
+      detailEl.textContent = info;
+    } else {
+      item.style.display = "none";
+    }
+  };
+  setDirectionInfo("walk", WALK_INFO);
+  setDirectionInfo("transit", TRANSIT_INFO);
+  setDirectionInfo("parking", PARKING_INFO);
+  const directionsSection = document.querySelector(".directions-section");
+  if (directionsSection) {
+    const hasInfo = [...directionsSection.querySelectorAll(".direction-item")].some(
+      (el) => el.style.display !== "none",
+    );
+    if (!hasInfo) directionsSection.style.display = "none";
+  }
+
+  const mapEl = document.getElementById("map");
+  if (mapEl) {
+    try {
+      await loadScript(
+        `https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${NAVER_MAP_API_KEY}`,
+      );
+      const position = new naver.maps.LatLng(VENUE_LAT, VENUE_LNG);
+      const map = new naver.maps.Map("map", {
+        center: position,
+        zoom: 15,
+      });
+      const marker = new naver.maps.Marker({ position, map });
+      const infoWindow = new naver.maps.InfoWindow({
+        content:
+          `<div style="padding:5px; word-break:break-all;"><div>${VENUE_LOCATION}</div><div>${VENUE_HALL}</div></div>`,
+      });
+      infoWindow.open(map, marker);
+    } catch (e) {
+      console.log(e);
+    }
+  }
 
   const calendarEl = document.getElementById("calendar");
   if (calendarEl) {
@@ -70,8 +146,8 @@ document.addEventListener("DOMContentLoaded", () => {
       if (navigator.share) {
         try {
           await navigator.share({
-            title: "이성우 ♥ 임상영 청첩장",
-            text: "2026년 5월 17일 메리빌리아더프레스티지\n가든홀",
+            title: `${GROOM_NAME} ♥ ${BRIDE_NAME} 청첩장`,
+            text: `${EVENT_DATE_TEXT} ${EVENT_TIME_TEXT} ${VENUE_LOCATION} ${VENUE_HALL}`,
             url: window.location.href,
           });
         } catch (e) {
@@ -86,14 +162,13 @@ document.addEventListener("DOMContentLoaded", () => {
   const shareKakaoBtn = document.getElementById("share-kakao");
   if (shareKakaoBtn && window.Kakao) {
     try {
-      Kakao.init("ad9882a7a0abfaffbde309e333d2e43e");
+      Kakao.init(KAKAO_API_KEY);
       shareKakaoBtn.addEventListener("click", () => {
         Kakao.Share.sendDefault({
           objectType: "feed",
           content: {
-            title: "이성우 ♥ 임상영 청첩장",
-            description:
-              "2026년 5월 17일 일요일 오전 10시 30분 메리빌리아더프레스티지\n가든홀",
+            title: `${GROOM_NAME} ♥ ${BRIDE_NAME} 청첩장`,
+            description: `${EVENT_DATE_TEXT} ${EVENT_TIME_TEXT} ${VENUE_LOCATION} ${VENUE_HALL}`,
             imageUrl: "https://www.iwedding.co.kr/center/iweddingb/product/800_17588_1730685980_90793400_3232256098.jpg",
             link: {
               mobileWebUrl: window.location.href,

--- a/style.css
+++ b/style.css
@@ -28,15 +28,26 @@ h6 {
   color: #fff;
 }
 
-.hero-content h1 {
+.hero-names {
   font-family: "Noto Sans KR", sans-serif;
   font-weight: 300;
   font-size: 3rem;
   margin: 0 0 16px;
+  line-height: 1.2;
+}
+
+.hero-names .groom,
+.hero-names .bride {
+  margin: 0;
+}
+
+.hero-names .groom::after {
+  content: " \2665";
 }
 
 .hero-content .date,
-.hero-content .location {
+.hero-content .location,
+.hero-content .hall {
   margin: 4px 0;
   font-size: 1.2rem;
 }
@@ -63,6 +74,15 @@ h6 {
   background: #f9f9f9;
 }
 
+.info-section .groom,
+.info-section .bride,
+.info-section .date,
+.info-section .time,
+.info-section .location,
+.info-section .hall {
+  margin: 4px 0;
+}
+
 .map-section,
 .calendar-section,
 .countdown-section,
@@ -76,6 +96,19 @@ h6 {
 .directions-section,
 .countdown-section {
   background: #f9f9f9;
+}
+
+.direction-item {
+  margin-bottom: 12px;
+}
+
+.direction-item .method {
+  margin: 0;
+  font-weight: 700;
+}
+
+.direction-item .detail {
+  margin: 4px 0 0;
 }
 
 .map-container {


### PR DESCRIPTION
## Summary
- Split groom, bride, date, time, and venue into dedicated fields and group directions by type
- Style new hero name block and direction items for clearer layout
- Centralize wedding constants in script and use them in share buttons
- Add transit direction entry and hide travel blocks with no info
- Move Naver map creation to script.js using shared constants and add alt text for share icons
- Extract Naver and Kakao API keys into constants and load the Naver map script dynamically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68942849d9dc8327be04a4acd1a1606c