### PR TITLE
feat: add theme switcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,10 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="themes.css" />
   </head>
   <body>
+    <button id="theme-button" class="theme-btn">🎨</button>
     <section class="hero-section">
       <div class="hero-content">
         <div class="hero-names">
@@ -177,5 +179,6 @@
       crossorigin="anonymous"
     ></script>
     <script src="script.js"></script>
+    <script src="theme.js"></script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -2,8 +2,8 @@ body {
   margin: 0;
   font-family: "Noto Sans KR", sans-serif;
   font-weight: 300;
-  background: #ffffff;
-  color: #333;
+  background: var(--bg-color);
+  color: var(--text-color);
   word-break: keep-all;
   letter-spacing: -0.02em;
   line-height: 1.8;
@@ -71,7 +71,7 @@ h6 {
 .info-section {
   padding: 40px 20px;
   text-align: center;
-  background: #f9f9f9;
+  background: var(--secondary-bg-color);
 }
 
 .info-section .groom,
@@ -95,7 +95,7 @@ h6 {
 
 .directions-section,
 .countdown-section {
-  background: #f9f9f9;
+  background: var(--secondary-bg-color);
 }
 
 .direction-item {
@@ -127,15 +127,15 @@ h6 {
   padding: 8px 14px;
   border: 1px solid #ddd;
   border-radius: 20px;
-  background: #fff;
-  color: #333;
+  background: var(--button-bg-color);
+  color: var(--button-text-color);
   text-decoration: none;
   font-size: 0.9rem;
   transition: background 0.2s ease;
 }
 
 .map-btn:hover {
-  background: #f5f5f5;
+  background: var(--button-hover-bg-color);
 }
 
 .btn-icon {
@@ -229,14 +229,14 @@ h6 {
   padding: 8px 20px;
   border: 1px solid #ddd;
   border-radius: 20px;
-  background: #fff;
-  color: #333;
+  background: var(--button-bg-color);
+  color: var(--button-text-color);
   cursor: pointer;
   transition: background 0.2s ease;
 }
 
 #gallery-more:hover {
-  background: #f5f5f5;
+  background: var(--button-hover-bg-color);
 }
 
 .image-modal {
@@ -295,8 +295,8 @@ h6 {
   padding: 8px 14px;
   border: 1px solid #ddd;
   border-radius: 20px;
-  background: #fff;
-  color: #333;
+  background: var(--button-bg-color);
+  color: var(--button-text-color);
   font-size: 1rem;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
   cursor: pointer;
@@ -304,7 +304,7 @@ h6 {
 }
 
 .share-section button:hover {
-  background: #f5f5f5;
+  background: var(--button-hover-bg-color);
 }
 
 .copy-toast {
@@ -329,8 +329,8 @@ h6 {
   text-align: center;
   padding: 20px;
   font-size: 0.9rem;
-  color: #999;
-  background: rgba(255, 255, 255, 0.9);
+  color: var(--text-color);
+  background: var(--button-bg-color);
 }
 
 .directions-section p {
@@ -338,7 +338,7 @@ h6 {
 }
 
 .highlight {
-  color: #b22222;
+  color: var(--highlight-color);
   font-weight: 700;
 }
 
@@ -351,4 +351,22 @@ h6 {
 .fade-section.visible {
   opacity: 1;
   transform: translateY(0);
+}
+
+.theme-btn {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 20px;
+  background: var(--button-bg-color);
+  color: var(--button-text-color);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  z-index: 1001;
+}
+
+.theme-btn:hover {
+  background: var(--button-hover-bg-color);
 }

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,20 @@
+const themes = ["default", "dark", "pastel-pink", "pastel-blue", "pastel-green"];
+let currentTheme = 0;
+
+document.addEventListener("DOMContentLoaded", () => {
+  const btn = document.getElementById("theme-button");
+  if (!btn) return;
+  btn.addEventListener("click", () => {
+    document.body.classList.remove(
+      "theme-dark",
+      "theme-pastel-pink",
+      "theme-pastel-blue",
+      "theme-pastel-green",
+    );
+    currentTheme = (currentTheme + 1) % themes.length;
+    const theme = themes[currentTheme];
+    if (theme !== "default") {
+      document.body.classList.add(`theme-${theme}`);
+    }
+  });
+});

--- a/themes.css
+++ b/themes.css
@@ -1,0 +1,49 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #333333;
+  --secondary-bg-color: #f9f9f9;
+  --button-bg-color: #ffffff;
+  --button-text-color: #333333;
+  --button-hover-bg-color: #f5f5f5;
+  --highlight-color: #b22222;
+}
+
+body.theme-dark {
+  --bg-color: #000000;
+  --text-color: #ffffff;
+  --secondary-bg-color: #333333;
+  --button-bg-color: #444444;
+  --button-text-color: #ffffff;
+  --button-hover-bg-color: #555555;
+  --highlight-color: #ff69b4;
+}
+
+body.theme-pastel-pink {
+  --bg-color: #ffe4e1;
+  --text-color: #5a5a5a;
+  --secondary-bg-color: #ffd5d2;
+  --button-bg-color: #ffffff;
+  --button-text-color: #5a5a5a;
+  --button-hover-bg-color: #f2cfcf;
+  --highlight-color: #ff1493;
+}
+
+body.theme-pastel-blue {
+  --bg-color: #e0f7fa;
+  --text-color: #5a5a5a;
+  --secondary-bg-color: #d0eff5;
+  --button-bg-color: #ffffff;
+  --button-text-color: #5a5a5a;
+  --button-hover-bg-color: #c8e9ef;
+  --highlight-color: #0077be;
+}
+
+body.theme-pastel-green {
+  --bg-color: #e6f4ea;
+  --text-color: #5a5a5a;
+  --secondary-bg-color: #d8eadb;
+  --button-bg-color: #ffffff;
+  --button-text-color: #5a5a5a;
+  --button-hover-bg-color: #d0e3d4;
+  --highlight-color: #2e8b57;
+}


### PR DESCRIPTION
## Summary
- add floating theme button
- support dark and pastel color themes
- convert colors to CSS variables for theming

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68942ed0cd7c83278c11fb51aa9d7991