### PR TITLE
fix: ensure map links use continuous URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,28 +82,8 @@
       <h3>오시는 길</h3>
       <div id="map" class="map-container"></div>
       <div class="map-buttons">
-        <a
-          class="map-btn"
-          href="https://map.naver.com/v5/search/%EB%A9%94%EB%A6%AC%EB%B9%8C%EB%A6%AC%EC%95%84%EB%8D%94%ED%94%84%EB%A0%88%EC%8A%A4%ED%8B%B0%EC%A7%80"
-          target="_blank"
-          rel="noopener"
-          ><img
-            src="https://play-lh.googleusercontent.com/iqe1hFI03eD6nW3S8fxK_MDvNC8tDtod_gnhF9e8XN-IPmLXJvZVJLm-bQ4U5mKAVK0"
-            alt="네이버맵 아이콘"
-            class="btn-icon"
-          />네이버 지도</a
-        >
-        <a
-          class="map-btn"
-          href="https://map.kakao.com/link/map/%EB%A9%94%EB%A6%AC%EB%B9%8C%EB%A6%AC%EC%95%84%EB%8D%94%ED%94%84%EB%A0%88%EC%8A%A4%ED%8B%B0%EC%A7%80,37.2627302,126.9966484"
-          target="_blank"
-          rel="noopener"
-          ><img
-            src="https://play-lh.googleusercontent.com/pPTTNz433EYFurg2j__bFU5ONdMoU_bs_-yS2JLZriua3iHrksGP6XBPF5VtDPlpGcW4"
-            alt="카카오맵 아이콘"
-            class="btn-icon"
-          />카카오 지도</a
-        >
+        <a class="map-btn" href="https://map.naver.com/v5/search/%EB%A9%94%EB%A6%AC%EB%B9%8C%EB%A6%AC%EC%95%84%EB%8D%94%ED%94%84%EB%A0%88%EC%8A%A4%ED%8B%B0%EC%A7%80" target="_blank" rel="noopener"><img src="https://play-lh.googleusercontent.com/iqe1hFI03eD6nW3S8fxK_MDvNC8tDtod_gnhF9e8XN-IPmLXJvZVJLm-bQ4U5mKAVK0" alt="네이버맵 아이콘" class="btn-icon" />네이버 지도</a>
+        <a class="map-btn" href="https://map.kakao.com/link/map/%EB%A9%94%EB%A6%AC%EB%B9%8C%EB%A6%AC%EC%95%84%EB%8D%94%ED%94%84%EB%A0%88%EC%8A%A4%ED%8B%B0%EC%A7%80,37.2627302,126.9966484" target="_blank" rel="noopener"><img src="https://play-lh.googleusercontent.com/pPTTNz433EYFurg2j__bFU5ONdMoU_bs_-yS2JLZriua3iHrksGP6XBPF5VtDPlpGcW4" alt="카카오맵 아이콘" class="btn-icon" />카카오 지도</a>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- collapse long Naver and Kakao map href values into single uninterrupted URLs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689431679f8c8327b7cead2273ea6f29