### PR TITLE
refactor: load API keys from env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ _site/
 # Node dependencies
 node_modules/
 
+# Local API key config
+config.js
+
 # Specific ignore for GitHub Pages
 # GitHub Pages will always use its own deployed version of pages-gem 
 # This means GitHub Pages will NOT use your Gemfile.lock and therefore it is

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Wedding Invitation
+
+This project uses API keys for Naver Map and Kakao services. The keys are not committed to version control.
+
+## API keys
+
+1. Copy `config.example.js` to `config.js`:
+   ```bash
+   cp config.example.js config.js
+   ```
+2. Edit `config.js` and replace the placeholders with your real keys:
+   ```js
+   window.env = {
+     NAVER_MAP_API_KEY: "your-naver-map-api-key",
+     KAKAO_API_KEY: "your-kakao-api-key",
+   };
+   ```
+3. For automated tests or local development, you can also supply the keys via environment variables:
+   ```bash
+   export NAVER_MAP_API_KEY=your-naver-map-api-key
+   export KAKAO_API_KEY=your-kakao-api-key
+   ```
+
+The application reads the keys from `window.env` or from the environment variables when running under Node.
+
+## Tests
+
+Run all tests with:
+
+```bash
+npm test
+```

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,4 @@
+window.env = {
+  NAVER_MAP_API_KEY: "your-naver-map-api-key",
+  KAKAO_API_KEY: "your-kakao-api-key",
+};

--- a/index.html
+++ b/index.html
@@ -178,6 +178,7 @@
       src="https://t1.kakaocdn.net/kakao_js_sdk/2.4.0/kakao.min.js"
       crossorigin="anonymous"
     ></script>
+    <script src="config.js"></script>
     <script src="script.js"></script>
     <script src="theme.js"></script>
   </body>

--- a/script.js
+++ b/script.js
@@ -10,8 +10,12 @@ const VENUE_LNG = 126.9966484;
 const WALK_INFO = "수원역 9번 출구에서 도보 10분";
 const TRANSIT_INFO = "";
 const PARKING_INFO = "예식장 내 주차장 이용 가능 (2시간 무료)";
-const NAVER_MAP_API_KEY = "yp02tw24ay";
-const KAKAO_API_KEY = "ad9882a7a0abfaffbde309e333d2e43e";
+const NAVER_MAP_API_KEY =
+  (typeof process !== "undefined" && process.env.NAVER_MAP_API_KEY) ||
+  (window.env && window.env.NAVER_MAP_API_KEY);
+const KAKAO_API_KEY =
+  (typeof process !== "undefined" && process.env.KAKAO_API_KEY) ||
+  (window.env && window.env.KAKAO_API_KEY);
 
 const loadScript = (src) =>
   new Promise((resolve, reject) => {

--- a/tests/apiKeys.test.js
+++ b/tests/apiKeys.test.js
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require("fs");
+const path = require("path");
+
+test("script.js loads API keys from environment", async () => {
+  process.env.NAVER_MAP_API_KEY = "naver_test";
+  process.env.KAKAO_API_KEY = "kakao_test";
+
+  document.body.innerHTML = `
+    <div id="map"></div>
+    <button id="share-kakao"></button>
+  `;
+
+  const appended = [];
+  const originalAppend = document.head.appendChild.bind(document.head);
+  document.head.appendChild = (el) => {
+    appended.push(el);
+    if (typeof el.onload === "function") {
+      el.onload();
+    }
+    return originalAppend(el);
+  };
+
+  global.Kakao = { init: jest.fn(), Share: { sendDefault: jest.fn() } };
+  global.naver = {
+    maps: {
+      LatLng: function () {},
+      Map: function () {},
+      Marker: function () {},
+      InfoWindow: function () {
+        return { open: function () {} };
+      },
+    },
+  };
+  global.IntersectionObserver = function () {
+    return { observe() {}, unobserve() {} };
+  };
+
+  const scriptContent = fs.readFileSync(
+    path.join(__dirname, "..", "script.js"),
+    "utf8",
+  );
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = scriptContent;
+  document.head.appendChild(scriptEl);
+
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(appended[1].src).toContain(
+    `ncpKeyId=${process.env.NAVER_MAP_API_KEY}`,
+  );
+  expect(Kakao.init).toHaveBeenCalledWith(process.env.KAKAO_API_KEY);
+});


### PR DESCRIPTION
## Summary
- load Naver Map and Kakao API keys from environment variables or config file
- add example config and README instructions for supplying keys
- test API key loading and usage with a new Jest test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689431753e6083278de105b4e5dc5685