### PR TITLE
Add alt text to gallery images

### DIFF
--- a/script.js
+++ b/script.js
@@ -216,6 +216,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     images.forEach((src, idx) => {
       const img = document.createElement("img");
       img.src = src;
+      img.alt = `gallery image ${idx + 1}`;
       img.className = "gallery-image";
       if (idx >= 9) img.classList.add("hidden");
       img.addEventListener("click", () => openModal(idx));


### PR DESCRIPTION
## Summary
- add descriptive alt text for images in gallery

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894317663208327b6a0dc73b83bf3e2