### PR TITLE
Persist theme selection and clean up theme class removal

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -1,20 +1,38 @@
 const themes = ["default", "dark", "pastel-pink", "pastel-blue", "pastel-green"];
 let currentTheme = 0;
 
+const removeThemeClasses = () => {
+  const themeClasses = Array.from(document.body.classList).filter((cls) =>
+    /^theme-/.test(cls),
+  );
+  if (themeClasses.length) {
+    document.body.classList.remove(...themeClasses);
+  }
+};
+
 document.addEventListener("DOMContentLoaded", () => {
+  removeThemeClasses();
+  const storedTheme = localStorage.getItem("currentTheme");
+  if (storedTheme !== null) {
+    const idx = parseInt(storedTheme, 10);
+    if (!Number.isNaN(idx)) {
+      currentTheme = idx % themes.length;
+      const theme = themes[currentTheme];
+      if (theme !== "default") {
+        document.body.classList.add(`theme-${theme}`);
+      }
+    }
+  }
+
   const btn = document.getElementById("theme-button");
   if (!btn) return;
   btn.addEventListener("click", () => {
-    document.body.classList.remove(
-      "theme-dark",
-      "theme-pastel-pink",
-      "theme-pastel-blue",
-      "theme-pastel-green",
-    );
+    removeThemeClasses();
     currentTheme = (currentTheme + 1) % themes.length;
     const theme = themes[currentTheme];
     if (theme !== "default") {
       document.body.classList.add(`theme-${theme}`);
     }
+    localStorage.setItem("currentTheme", String(currentTheme));
   });
 });


### PR DESCRIPTION
## Summary
- load saved theme on page load and persist changes to localStorage
- replace hardcoded theme class removal with generic `theme-*` cleanup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68943177e10083278d49ca86d62cdd50