### PR TITLE
Update example API keys for Naver and Kakao

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wedding Invitation
 
-This project uses API keys for Naver Map and Kakao services. The keys are not committed to version control.
+This project uses API keys for Naver Map and Kakao services. Example keys are provided in the repository.
 
 ## API keys
 
@@ -8,17 +8,18 @@ This project uses API keys for Naver Map and Kakao services. The keys are not co
    ```bash
    cp config.example.js config.js
    ```
-2. Edit `config.js` and replace the placeholders with your real keys:
+2. The configuration includes ready-to-use keys:
    ```js
    window.env = {
-     NAVER_MAP_API_KEY: "your-naver-map-api-key",
-     KAKAO_API_KEY: "your-kakao-api-key",
+     NAVER_MAP_API_KEY: "yp02tw24ay",
+     KAKAO_API_KEY: "ad9882a7a0abfaffbde309e333d2e43e",
    };
    ```
+   If you need to use different keys, edit `config.js` accordingly.
 3. For automated tests or local development, you can also supply the keys via environment variables:
    ```bash
-   export NAVER_MAP_API_KEY=your-naver-map-api-key
-   export KAKAO_API_KEY=your-kakao-api-key
+   export NAVER_MAP_API_KEY=yp02tw24ay
+   export KAKAO_API_KEY=ad9882a7a0abfaffbde309e333d2e43e
    ```
 
 The application reads the keys from `window.env` or from the environment variables when running under Node.

--- a/config.example.js
+++ b/config.example.js
@@ -1,4 +1,4 @@
 window.env = {
-  NAVER_MAP_API_KEY: "your-naver-map-api-key",
-  KAKAO_API_KEY: "your-kakao-api-key",
+  NAVER_MAP_API_KEY: "yp02tw24ay",
+  KAKAO_API_KEY: "ad9882a7a0abfaffbde309e333d2e43e",
 };


### PR DESCRIPTION
## Summary
- update `config.example.js` with new Naver and Kakao API keys
- document keys in README for easier setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689436122030832784e5563c094a38b8