### PR TITLE
Add config.js for API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ _site/
 # Node dependencies
 node_modules/
 
-# Local API key config
-config.js
 
 # Specific ignore for GitHub Pages
 # GitHub Pages will always use its own deployed version of pages-gem 

--- a/config.js
+++ b/config.js
@@ -1,0 +1,4 @@
+window.env = {
+  NAVER_MAP_API_KEY: "yp02tw24ay",
+  KAKAO_API_KEY: "ad9882a7a0abfaffbde309e333d2e43e",
+};


### PR DESCRIPTION
## Summary
- add `config.js` with default API keys
- allow `config.js` to be tracked by removing ignore rule

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689437939bf88327b28f95d554bac646