### PR TITLE
feat: update contact modal layout and styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -55,29 +55,74 @@ const getTemplate = () => `
   </section>
 
   <section class="info-section fade-section">
-    <h3>예식 안내</h3>
-    <p class="info-line">${GROOM_FATHER} | ${GROOM_MOTHER}의 아들 ${GROOM_NAME}</p>
-    <p class="info-line">${BRIDE_FATHER} | ${BRIDE_MOTHER}의 딸 ${BRIDE_NAME}</p>
-    <p class="datetime">${EVENT_DATETIME_TEXT}</p>
-    <p class="location">${VENUE_LOCATION}</p>
-    <p class="hall">${VENUE_HALL}</p>
+    <h3>마음 전하는 곳</h3>
+    <p class="info-line">父 ${GROOM_FATHER} | 母 ${GROOM_MOTHER}의 아들 ${GROOM_NAME}</p>
+    <p class="info-line">父 ${BRIDE_FATHER} | 母 ${BRIDE_MOTHER}의 딸 ${BRIDE_NAME}</p>
     <button id="contact-btn" class="contact-btn">연락하기</button>
   </section>
 
   <div id="contact-modal" class="contact-modal">
     <div class="contact-content">
       <button id="contact-close" class="modal-close">&times;</button>
-      <ul class="contact-list">
-        <li>신랑 ${GROOM_NAME}<a href="tel:${GROOM_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" class="call-icon" />${GROOM_PHONE}</a></li>
-        <li>신랑 아버지 ${GROOM_FATHER}<a href="tel:${GROOM_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" class="call-icon" />${GROOM_FATHER_PHONE}</a></li>
-        <li>신랑 어머니 ${GROOM_MOTHER}<a href="tel:${GROOM_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" class="call-icon" />${GROOM_MOTHER_PHONE}</a></li>
-        <li>신부 ${BRIDE_NAME}<a href="tel:${BRIDE_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" class="call-icon" />${BRIDE_PHONE}</a></li>
-        <li>신부 아버지 ${BRIDE_FATHER}<a href="tel:${BRIDE_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" class="call-icon" />${BRIDE_FATHER_PHONE}</a></li>
-        <li>신부 어머니 ${BRIDE_MOTHER}<a href="tel:${BRIDE_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" class="call-icon" />${BRIDE_MOTHER_PHONE}</a></li>
-      </ul>
-      <div class="account-info">
-        신랑: ${GROOM_ACCOUNT}<br />
-        신부: ${BRIDE_ACCOUNT}
+      <div class="contact-columns">
+        <div class="contact-column">
+          <ul class="contact-list">
+            <li>
+              <span>${GROOM_NAME}</span>
+              <span class="contact-actions">
+                <a href="tel:${GROOM_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
+                <a href="sms:${GROOM_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
+              </span>
+            </li>
+            <li>
+              <span>父 ${GROOM_FATHER}</span>
+              <span class="contact-actions">
+                <a href="tel:${GROOM_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
+                <a href="sms:${GROOM_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
+              </span>
+            </li>
+            <li>
+              <span>母 ${GROOM_MOTHER}</span>
+              <span class="contact-actions">
+                <a href="tel:${GROOM_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
+                <a href="sms:${GROOM_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
+              </span>
+            </li>
+            <li class="account">
+              <span>${GROOM_ACCOUNT}</span>
+              <button class="copy-account" data-account="${GROOM_ACCOUNT}"><img src="https://img.icons8.com/ios-glyphs/16/copy.png" alt="복사" /></button>
+            </li>
+          </ul>
+        </div>
+        <div class="contact-column">
+          <ul class="contact-list">
+            <li>
+              <span>${BRIDE_NAME}</span>
+              <span class="contact-actions">
+                <a href="tel:${BRIDE_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
+                <a href="sms:${BRIDE_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
+              </span>
+            </li>
+            <li>
+              <span>父 ${BRIDE_FATHER}</span>
+              <span class="contact-actions">
+                <a href="tel:${BRIDE_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
+                <a href="sms:${BRIDE_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
+              </span>
+            </li>
+            <li>
+              <span>母 ${BRIDE_MOTHER}</span>
+              <span class="contact-actions">
+                <a href="tel:${BRIDE_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
+                <a href="sms:${BRIDE_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
+              </span>
+            </li>
+            <li class="account">
+              <span>${BRIDE_ACCOUNT}</span>
+              <button class="copy-account" data-account="${BRIDE_ACCOUNT}"><img src="https://img.icons8.com/ios-glyphs/16/copy.png" alt="복사" /></button>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>
@@ -388,6 +433,22 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (e.target === contactModal) contactModal.classList.remove("open");
     });
   }
+
+  const accountCopyBtns = document.querySelectorAll(".copy-account");
+  accountCopyBtns.forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText(btn.dataset.account);
+        if (copyToast) {
+          copyToast.textContent = "계좌번호가 복사되었습니다";
+          copyToast.classList.add("show");
+          setTimeout(() => copyToast.classList.remove("show"), 2000);
+        }
+      } catch (e) {
+        console.log(e);
+      }
+    });
+  });
 
   const shareSection = document.querySelector(".share-section");
   const isMobile = /Mobi|Android/i.test(navigator.userAgent);

--- a/style.css
+++ b/style.css
@@ -44,7 +44,7 @@ h6 {
   justify-content: center;
   align-items: center;
   font-family: "Noto Sans KR", sans-serif;
-  font-weight: 300;
+  font-weight: 400;
   font-size: 3rem;
   margin: 0 0 16px;
   line-height: 1.2;
@@ -63,12 +63,12 @@ h6 {
 }
 
 .hero-content .location {
-  margin: 16px 0 4px;
+  margin: 16px 0 2px;
   font-size: 1.2rem;
 }
 
 .hero-content .hall {
-  margin: 4px 0;
+  margin: 2px 0;
   font-size: 1.2rem;
 }
 
@@ -384,8 +384,8 @@ h6 {
   background: #fff;
   padding: 20px;
   border-radius: 8px;
-  width: 80%;
-  max-width: 320px;
+  width: 90%;
+  max-width: 480px;
   text-align: left;
 }
 
@@ -399,10 +399,19 @@ h6 {
   cursor: pointer;
 }
 
+.contact-columns {
+  display: flex;
+}
+
+.contact-column {
+  flex: 1;
+  padding: 0 10px;
+}
+
 .contact-list {
   list-style: none;
   padding: 0;
-  margin: 0 0 16px;
+  margin: 0;
 }
 
 .contact-list li {
@@ -412,20 +421,29 @@ h6 {
   align-items: center;
 }
 
-.contact-list a {
+.contact-actions a {
+  margin-left: 8px;
   text-decoration: none;
   color: var(--text-color);
-  display: flex;
-  align-items: center;
 }
 
-.call-icon {
-  margin-right: 4px;
+.contact-actions a:first-child {
+  margin-left: 0;
 }
 
-.account-info {
-  font-size: 0.9rem;
-  line-height: 1.4;
+.contact-list .account {
+  margin-top: 16px;
+}
+
+.contact-list .account button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.contact-list .account img {
+  margin-left: 8px;
 }
 
 .footer {


### PR DESCRIPTION
## Summary
- tweak hero name typography and spacing
- rename info section to "마음 전하는 곳" and remove event details
- split contact modal for groom and bride with call/sms icons and account copy buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689446adfd088327818f28519981c9b3