### PR TITLE
feat: enhance info and contact sections

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,8 +21,10 @@ const GROOM_FATHER_PHONE = "010-1111-2222";
 const GROOM_MOTHER_PHONE = "010-3333-4444";
 const BRIDE_FATHER_PHONE = "010-5555-6666";
 const BRIDE_MOTHER_PHONE = "010-7777-8888";
-const GROOM_ACCOUNT = "국민은행 123456-78-901234";
-const BRIDE_ACCOUNT = "신한은행 987654-32-109876";
+const GROOM_ACCOUNT_BANK = "국민은행";
+const GROOM_ACCOUNT_NUMBER = "123456-78-901234";
+const BRIDE_ACCOUNT_BANK = "신한은행";
+const BRIDE_ACCOUNT_NUMBER = "987654-32-109876";
 const NAVER_MAP_API_KEY =
   (typeof process !== "undefined" && process.env.NAVER_MAP_API_KEY) ||
   (window.env && window.env.NAVER_MAP_API_KEY);
@@ -55,9 +57,25 @@ const getTemplate = () => `
   </section>
 
   <section class="info-section fade-section">
-    <h3>마음 전하는 곳</h3>
-    <p class="info-line">父 ${GROOM_FATHER} | 母 ${GROOM_MOTHER}의 아들 ${GROOM_NAME}</p>
-    <p class="info-line">父 ${BRIDE_FATHER} | 母 ${BRIDE_MOTHER}의 딸 ${BRIDE_NAME}</p>
+    <img src="https://img.icons8.com/ios-filled/50/wedding-rings.png" alt="마음 전하는 곳" class="info-title" />
+    <p class="info-line">
+      <span>아버지</span>
+      <span class="info-name">${GROOM_FATHER}</span>
+      <span>|</span>
+      <span>어머니</span>
+      <span class="info-name">${GROOM_MOTHER}</span>
+      <span class="relation">의 아들</span>
+      <span class="info-name">${GROOM_NAME}</span>
+    </p>
+    <p class="info-line">
+      <span>아버지</span>
+      <span class="info-name">${BRIDE_FATHER}</span>
+      <span>|</span>
+      <span>어머니</span>
+      <span class="info-name">${BRIDE_MOTHER}</span>
+      <span class="relation">의 딸</span>
+      <span class="info-name">${BRIDE_NAME}</span>
+    </p>
     <button id="contact-btn" class="contact-btn">연락하기</button>
   </section>
 
@@ -68,7 +86,7 @@ const getTemplate = () => `
         <div class="contact-column">
           <ul class="contact-list">
             <li>
-              <span>${GROOM_NAME}</span>
+              <span>신랑 ${GROOM_NAME}</span>
               <span class="contact-actions">
                 <a href="tel:${GROOM_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
                 <a href="sms:${GROOM_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
@@ -89,15 +107,18 @@ const getTemplate = () => `
               </span>
             </li>
             <li class="account">
-              <span>${GROOM_ACCOUNT}</span>
-              <button class="copy-account" data-account="${GROOM_ACCOUNT}"><img src="https://img.icons8.com/ios-glyphs/16/copy.png" alt="복사" /></button>
+              <div class="account-info">
+                <span class="bank">${GROOM_ACCOUNT_BANK}</span>
+                <span class="account-number">${GROOM_ACCOUNT_NUMBER}</span>
+              </div>
+              <button class="copy-account" data-account="${GROOM_ACCOUNT_BANK} ${GROOM_ACCOUNT_NUMBER}"><img src="https://img.icons8.com/ios-glyphs/16/copy.png" alt="복사" /></button>
             </li>
           </ul>
         </div>
         <div class="contact-column">
           <ul class="contact-list">
             <li>
-              <span>${BRIDE_NAME}</span>
+              <span>신부 ${BRIDE_NAME}</span>
               <span class="contact-actions">
                 <a href="tel:${BRIDE_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
                 <a href="sms:${BRIDE_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
@@ -118,8 +139,11 @@ const getTemplate = () => `
               </span>
             </li>
             <li class="account">
-              <span>${BRIDE_ACCOUNT}</span>
-              <button class="copy-account" data-account="${BRIDE_ACCOUNT}"><img src="https://img.icons8.com/ios-glyphs/16/copy.png" alt="복사" /></button>
+              <div class="account-info">
+                <span class="bank">${BRIDE_ACCOUNT_BANK}</span>
+                <span class="account-number">${BRIDE_ACCOUNT_NUMBER}</span>
+              </div>
+              <button class="copy-account" data-account="${BRIDE_ACCOUNT_BANK} ${BRIDE_ACCOUNT_NUMBER}"><img src="https://img.icons8.com/ios-glyphs/16/copy.png" alt="복사" /></button>
             </li>
           </ul>
         </div>

--- a/style.css
+++ b/style.css
@@ -92,6 +92,27 @@ h6 {
 
 .info-line {
   margin: 4px 0;
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+}
+
+.info-title {
+  display: block;
+  width: 50px;
+  height: 50px;
+  margin: 0 auto 16px;
+}
+
+.info-name {
+  font-weight: 600;
+  font-size: 1.1em;
+}
+
+.info-line .relation {
+  display: inline-block;
+  width: 3em;
+  text-align: center;
 }
 
 .info-section .datetime,
@@ -382,10 +403,10 @@ h6 {
 .contact-content {
   position: relative;
   background: #fff;
-  padding: 20px;
+  padding: 28px 32px;
   border-radius: 8px;
   width: 90%;
-  max-width: 480px;
+  max-width: 560px;
   text-align: left;
 }
 
@@ -408,6 +429,15 @@ h6 {
   padding: 0 10px;
 }
 
+.contact-column:first-child {
+  border-right: 1px solid #eee;
+  padding-right: 20px;
+}
+
+.contact-column:last-child {
+  padding-left: 20px;
+}
+
 .contact-list {
   list-style: none;
   padding: 0;
@@ -415,7 +445,7 @@ h6 {
 }
 
 .contact-list li {
-  margin-bottom: 8px;
+  margin-bottom: 12px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -427,12 +457,28 @@ h6 {
   color: var(--text-color);
 }
 
+.contact-actions img,
+.copy-account img {
+  opacity: 0.6;
+  transition: opacity 0.2s;
+}
+
+.contact-actions img:hover,
+.copy-account img:hover {
+  opacity: 1;
+}
+
 .contact-actions a:first-child {
   margin-left: 0;
 }
 
 .contact-list .account {
   margin-top: 16px;
+  align-items: flex-start;
+}
+
+.account-info span {
+  display: block;
 }
 
 .contact-list .account button {
@@ -440,9 +486,6 @@ h6 {
   border: none;
   padding: 0;
   cursor: pointer;
-}
-
-.contact-list .account img {
   margin-left: 8px;
 }
 


### PR DESCRIPTION
## Summary
- replace '마음 전하는 곳' heading with wedding icon and emphasize family names
- widen contact popup with clearer columns and translucent action icons
- show bank and account info on separate lines for easier copying

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68944943cba08327a728ff59a4c601de