### PR TITLE
Fix initialization timing for wedding invitation page

### DIFF
--- a/script.js
+++ b/script.js
@@ -242,7 +242,7 @@ const loadScript = (src) =>
     document.head.appendChild(s);
   });
 
-document.addEventListener("DOMContentLoaded", async () => {
+const init = async () => {
   document.body.innerHTML = getTemplate();
   const eventDate = new Date(2026, 4, 17, 10, 30);
   const setDirectionInfo = (cls, info) => {
@@ -499,4 +499,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     { threshold: 0.1 },
   );
   fadeSections.forEach((sec) => observer.observe(sec));
-});
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", init);
+} else {
+  init();
+}

--- a/tests/init.test.js
+++ b/tests/init.test.js
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require("fs");
+const path = require("path");
+
+test("script.js initializes immediately if DOM is ready", async () => {
+  document.body.innerHTML = "";
+  Object.defineProperty(document, "readyState", { value: "complete", configurable: true });
+
+  const appended = [];
+  const originalAppend = document.head.appendChild.bind(document.head);
+  document.head.appendChild = (el) => {
+    appended.push(el);
+    if (typeof el.onload === "function") {
+      el.onload();
+    }
+    return originalAppend(el);
+  };
+
+  global.naver = {
+    maps: {
+      LatLng: function () {},
+      Map: function () {},
+      Marker: function () {},
+      InfoWindow: function () {
+        return { open: function () {} };
+      },
+    },
+  };
+  global.Kakao = { init: jest.fn(), Share: { sendDefault: jest.fn() } };
+  global.IntersectionObserver = function () {
+    return { observe() {}, unobserve() {} };
+  };
+
+  const scriptContent = fs.readFileSync(
+    path.join(__dirname, "..", "script.js"),
+    "utf8",
+  );
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = scriptContent;
+  document.head.appendChild(scriptEl);
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const hero = document.querySelector(".hero-section");
+  expect(hero).not.toBeNull();
+});


### PR DESCRIPTION
## Summary
- ensure main script runs even when DOM has already loaded
- add regression test for post-DOMContentLoaded initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689456cd82e88327956aeb3270ddb3fe