### PR TITLE
fix: rename duplicate loadScript

### DIFF
--- a/script.js
+++ b/script.js
@@ -233,7 +233,7 @@ const getTemplate = () => `
   <footer class="footer">© 2024 Wedding Invitation</footer>
 `;
 
-const loadScript = (src) =>
+const loadExternalScript = (src) =>
   new Promise((resolve, reject) => {
     const s = document.createElement("script");
     s.src = src;
@@ -269,7 +269,7 @@ const init = async () => {
   const mapEl = document.getElementById("map");
   if (mapEl) {
     try {
-      await loadScript(
+      await loadExternalScript(
         `https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${NAVER_MAP_API_KEY}`,
       );
       const position = new naver.maps.LatLng(VENUE_LAT, VENUE_LNG);


### PR DESCRIPTION
## Summary
- rename internal script loading helper to avoid global name collision

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894600e3b108327baf7d39f91550a97