### PR TITLE
Show full event date in calendar header

### DIFF
--- a/script.js
+++ b/script.js
@@ -294,7 +294,7 @@ const init = async () => {
     const month = eventDate.getMonth();
     const firstDay = new Date(year, month, 1).getDay();
     const lastDate = new Date(year, month + 1, 0).getDate();
-    let html = `<div class="calendar-header">${year}. ${String(month + 1).padStart(2, "0")}</div>`;
+    let html = `<div class="calendar-header">${year}. ${String(month + 1).padStart(2, "0")}. ${String(eventDate.getDate()).padStart(2, "0")}</div>`;
     html += "<table><thead><tr>";
     const days = ["일", "월", "화", "수", "목", "금", "토"];
     html += days.map((d) => `<th>${d}</th>`).join("");


### PR DESCRIPTION
## Summary
- display year, month, and day in calendar header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894623e4a488327b6cac4f141964c1f