### PR TITLE
feat: refine calendar header display

### DIFF
--- a/script.js
+++ b/script.js
@@ -304,7 +304,7 @@ const init = async () => {
     const month = eventDate.getMonth();
     const firstDay = new Date(year, month, 1).getDay();
     const lastDate = new Date(year, month + 1, 0).getDate();
-    let html = `<div class="calendar-header">${year}. ${String(month + 1).padStart(2, "0")}. ${String(eventDate.getDate()).padStart(2, "0")}.</div>`;
+    let html = `<div class="calendar-header">${year} / ${String(month + 1).padStart(2, "0")} / ${String(eventDate.getDate()).padStart(2, "0")}</div>`;
     html += "<table><thead><tr>";
     const days = ["일", "월", "화", "수", "목", "금", "토"];
     html += days.map((d) => `<th>${d}</th>`).join("");

--- a/style.css
+++ b/style.css
@@ -224,12 +224,11 @@ h6 {
 
 .calendar-header {
   font-size: 1.2rem;
-  font-weight: 700;
+  font-weight: 400;
   margin-bottom: 8px;
-  display: inline-block;
-  padding: 4px 12px;
-  border-radius: 12px;
-  background: #e0e0e0;
+  padding: 8px 0;
+  border-top: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
   color: #333;
 }
 


### PR DESCRIPTION
## Summary
- format calendar date as `2026 / 05 / 17`
- restyle calendar header with borders and lighter font

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68947511a9c48327bbd1e0856034e3c1