### PR TITLE
Refine map and calendar styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -62,20 +62,22 @@ const getTemplate = () => `
   <section class="family-contact-section fade-section">
     <img src="https://picsum.photos/seed/wed0/600/400" alt="contact photo" class="contact-image" />
     <div class="family-section">
-      <p class="info-line">
-        <span class="info-name">${GROOM_FATHER}</span>
-        <span class="name-dot">·</span>
-        <span class="info-name">${GROOM_MOTHER}</span>
-        <span class="relation">의 아들</span>
-        <span class="info-name child-name">${GROOM_FIRST_NAME}</span>
-      </p>
-      <p class="info-line">
-        <span class="info-name">${BRIDE_FATHER}</span>
-        <span class="name-dot">·</span>
-        <span class="info-name">${BRIDE_MOTHER}</span>
-        <span class="relation">의 딸</span>
-        <span class="info-name child-name">${BRIDE_FIRST_NAME}</span>
-      </p>
+        <p class="info-line">
+          <span class="info-name">${GROOM_FATHER}</span>
+          <span class="name-dot">·</span>
+          <span class="info-name">${GROOM_MOTHER}</span>
+          <span class="relation">의</span>
+          <span class="relation-child">아들</span>
+          <span class="info-name child-name">${GROOM_FIRST_NAME}</span>
+        </p>
+        <p class="info-line">
+          <span class="info-name">${BRIDE_FATHER}</span>
+          <span class="name-dot">·</span>
+          <span class="info-name">${BRIDE_MOTHER}</span>
+          <span class="relation">의</span>
+          <span class="relation-child">딸</span>
+          <span class="info-name child-name">${BRIDE_FIRST_NAME}</span>
+        </p>
     </div>
     <button id="contact-btn" class="contact-btn">연락하기</button>
   </section>
@@ -302,7 +304,7 @@ const init = async () => {
       const marker = new naver.maps.Marker({ position, map });
       const infoWindow = new naver.maps.InfoWindow({
         content:
-          `<div style="padding:5px; word-break:break-all; font-size:12px;"><div>${VENUE_ADDRESS}</div><div>${VENUE_HALL}</div></div>`,
+          `<div style="padding:5px; word-break:break-all; font-size:12px;"><div>${VENUE_LOCATION}</div><div>${VENUE_HALL}</div></div>`,
       });
       infoWindow.open(map, marker);
     } catch (e) {

--- a/style.css
+++ b/style.css
@@ -132,10 +132,9 @@ h6 {
 }
 
 .info-line .relation {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 3em;
+  display: inline-block;
+  width: 1em;
+  text-align: center;
 }
 
 .family-contact-section {
@@ -174,8 +173,18 @@ h6 {
   margin-top: 10px;
 }
 
+.calendar-section {
+  background: var(--secondary-bg-color);
+}
+
 .countdown-section {
   background: var(--secondary-bg-color);
+}
+
+.map-section h3,
+.countdown-section h3 {
+  font-size: 1.5em;
+  font-weight: 400;
 }
 
 .direction-item {
@@ -197,7 +206,7 @@ h6 {
 
 .map-section .map-address {
   margin: 8px 0 12px;
-  font-weight: 500;
+  font-weight: 300;
 }
 
 .direction-item .detail {
@@ -240,6 +249,13 @@ h6 {
   margin-right: 4px;
   vertical-align: middle;
   display: block;
+}
+
+.calendar-container {
+  background: #fff;
+  padding: 20px;
+  border-radius: 12px;
+  display: inline-block;
 }
 
 .calendar-header {
@@ -430,17 +446,6 @@ h6 {
   cursor: pointer;
   transition: background 0.2s ease;
   position: relative;
-}
-
-.share-section button + button::before {
-  content: "";
-  position: absolute;
-  left: -8px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 1px;
-  height: 24px;
-  background: #ddd;
 }
 
 
@@ -637,7 +642,7 @@ h6 {
   padding: 20px;
   font-size: 0.9rem;
   color: var(--text-color);
-  background: var(--button-bg-color);
+  background: var(--secondary-bg-color);
 }
 
 .highlight {


### PR DESCRIPTION
## Summary
- Align family relation labels and lighten map address
- Simplify map marker text and remove share button divider
- Style calendar and footer to match countdown aesthetics and unify section titles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689541688c5c832799caea4159f81126