### PR TITLE
Fix calendar overflow and gallery modal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="preload" as="image" href="https://picsum.photos/seed/wed0/600/400" />
     <link id="main-style" rel="stylesheet" />
     <script>
       window.CACHE_BUSTER = `?v=${Date.now()}`;

--- a/script.js
+++ b/script.js
@@ -60,7 +60,7 @@ const getTemplate = () => `
     </p>
   </section>
   <section class="family-contact-section fade-section">
-    <img src="https://picsum.photos/seed/wed0/600/400" alt="contact photo" class="contact-image" />
+    <img src="https://picsum.photos/seed/wed0/600/400" alt="contact photo" class="contact-image" width="600" height="400" loading="eager" />
     <div class="family-section">
         <p class="info-line">
           <span class="info-name parent-name">${GROOM_FATHER}</span>
@@ -432,6 +432,7 @@ const init = async () => {
     const moreBtn = document.getElementById("gallery-more");
     const modal = document.getElementById("image-modal");
     const modalTrack = document.getElementById("modal-track");
+    const modalWindow = document.querySelector(".modal-window");
     const trackImgs = modalTrack.querySelectorAll("img");
     const prevBtn = document.getElementById("modal-prev");
     const nextBtn = document.getElementById("modal-next");
@@ -444,7 +445,7 @@ const init = async () => {
       trackImgs[0].src = images[prevIndex];
       trackImgs[1].src = images[currentIndex];
       trackImgs[2].src = images[nextIndex];
-      modalTrack.style.transform = "translateX(-100%)";
+      modalTrack.style.transform = `translateX(-${modalWindow.clientWidth}px)`;
     };
 
     const openModal = (idx) => {
@@ -456,7 +457,9 @@ const init = async () => {
 
     const slideTo = (dir) => {
       modalTrack.style.transition = "transform 0.3s";
-      modalTrack.style.transform = `translateX(${dir === "next" ? -200 : 0}%)`;
+      modalTrack.style.transform = `translateX(-${
+        dir === "next" ? modalWindow.clientWidth * 2 : 0
+      }px)`;
       modalTrack.addEventListener(
         "transitionend",
         () => {
@@ -496,7 +499,7 @@ const init = async () => {
     });
     modalTrack.addEventListener("touchmove", (e) => {
       const diff = e.touches[0].clientX - startX;
-      modalTrack.style.transform = `translateX(calc(-100% + ${diff}px))`;
+      modalTrack.style.transform = `translateX(${-modalWindow.clientWidth + diff}px)`;
     });
     modalTrack.addEventListener("touchend", (e) => {
       const diff = e.changedTouches[0].clientX - startX;
@@ -506,14 +509,14 @@ const init = async () => {
         slideTo("prev");
       } else {
         modalTrack.style.transition = "transform 0.3s";
-        modalTrack.style.transform = "translateX(-100%)";
+        modalTrack.style.transform = `translateX(-${modalWindow.clientWidth}px)`;
       }
     });
     const closeGallery = () => {
       modal.classList.remove("open");
       document.body.classList.remove("no-scroll");
       modalTrack.style.transition = "none";
-      modalTrack.style.transform = "translateX(-100%)";
+      modalTrack.style.transform = `translateX(-${modalWindow.clientWidth}px)`;
     };
     closeBtn.addEventListener("click", closeGallery);
     modal.addEventListener("click", (e) => {

--- a/style.css
+++ b/style.css
@@ -279,6 +279,7 @@ h6 {
   width: 100%;
   max-width: 400px;
   margin: 0 auto;
+  box-sizing: border-box;
 }
 
 .calendar-header {
@@ -329,8 +330,12 @@ h6 {
 .calendar-container .event-day::before {
   content: "❤";
   position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   font-size: 32px;
   color: #f0e6f6;
+  z-index: -1;
 }
 
 #countdown {
@@ -397,6 +402,7 @@ h6 {
   background: rgba(0, 0, 0, 0.8);
   justify-content: center;
   align-items: center;
+  flex-direction: column;
   z-index: 1000;
 }
 
@@ -412,14 +418,13 @@ h6 {
 
 .modal-track {
   display: flex;
-  width: 300%;
   transform: translateX(-100%);
   transition: transform 0.3s ease;
 }
 
 .modal-track img {
-  width: 80%;
-  margin: 0 10%;
+  width: 100%;
+  margin: 0;
   flex-shrink: 0;
   border-radius: 8px;
 }
@@ -447,10 +452,6 @@ h6 {
 }
 
 .modal-close {
-  position: absolute;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
   background: rgba(255, 255, 255, 0.7);
   border: none;
   width: 40px;
@@ -458,6 +459,7 @@ h6 {
   border-radius: 50%;
   font-size: 1.2rem;
   cursor: pointer;
+  margin-top: 10px;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- prevent calendar from overflowing and display event number inside heart
- preload contact image to smooth initial animation
- realign gallery modal images and reposition close button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68954a7fe8c48327828d0116dbe39b4d