### PR TITLE
Fix contact modal spacing and font weight

### DIFF
--- a/script.js
+++ b/script.js
@@ -65,14 +65,16 @@ const getTemplate = () => `
         <p class="info-line">
           <span class="info-name parent-name">${GROOM_FATHER}</span>
           <span class="name-dot">·</span>
-          <span class="info-name parent-name">${GROOM_MOTHER}의</span>
+          <span class="info-name parent-name">${GROOM_MOTHER}</span>
+          <span class="relation-particle">의</span>
           <span class="relation-child">아들</span>
           <span class="info-name child-name">${GROOM_FIRST_NAME}</span>
         </p>
         <p class="info-line">
           <span class="info-name parent-name">${BRIDE_FATHER}</span>
           <span class="name-dot">·</span>
-          <span class="info-name parent-name">${BRIDE_MOTHER}의</span>
+          <span class="info-name parent-name">${BRIDE_MOTHER}</span>
+          <span class="relation-particle">의</span>
           <span class="relation-child">딸</span>
           <span class="info-name child-name">${BRIDE_FIRST_NAME}</span>
         </p>

--- a/style.css
+++ b/style.css
@@ -149,6 +149,11 @@ h6 {
   text-align: left;
 }
 
+.info-line .relation-particle {
+  display: inline-block;
+  font-weight: 400;
+}
+
 .family-contact-section {
   padding: 40px 20px;
   text-align: center;
@@ -540,8 +545,9 @@ h6 {
 
 .contact-content .modal-close {
   position: absolute;
-  top: 8px;
+  top: 4px;
   right: 8px;
+  margin-top: 0;
   background: transparent;
   border: none;
   font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- Reduce top spacing above close button in contact modal
- Ensure the particle "의" uses normal font weight to match relation labels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895760bb688832780a15e6ae308eeee