### PR TITLE
Adjust contact modal layout and relation formatting

### DIFF
--- a/script.js
+++ b/script.js
@@ -65,16 +65,14 @@ const getTemplate = () => `
         <p class="info-line">
           <span class="info-name parent-name">${GROOM_FATHER}</span>
           <span class="name-dot">·</span>
-          <span class="info-name parent-name">${GROOM_MOTHER}</span>
-          <span class="relation-particle">의</span>
+          <span class="info-name parent-name">${GROOM_MOTHER}</span><span class="relation-particle">의</span>
           <span class="relation-child">아들</span>
           <span class="info-name child-name">${GROOM_FIRST_NAME}</span>
         </p>
         <p class="info-line">
           <span class="info-name parent-name">${BRIDE_FATHER}</span>
           <span class="name-dot">·</span>
-          <span class="info-name parent-name">${BRIDE_MOTHER}</span>
-          <span class="relation-particle">의</span>
+          <span class="info-name parent-name">${BRIDE_MOTHER}</span><span class="relation-particle">의</span>
           <span class="relation-child">딸</span>
           <span class="info-name child-name">${BRIDE_FIRST_NAME}</span>
         </p>
@@ -84,7 +82,6 @@ const getTemplate = () => `
 
   <div id="contact-modal" class="contact-modal">
     <div class="contact-content">
-      <button id="contact-close" class="modal-close">&times;</button>
       <div class="contact-columns">
         <div class="contact-column">
           <ul class="contact-list">
@@ -173,6 +170,7 @@ const getTemplate = () => `
       </div>
       <div id="contact-toast" class="copy-toast"></div>
     </div>
+    <button id="contact-close" class="modal-close">&times;</button>
   </div>
 
   <section class="map-section fade-section">

--- a/style.css
+++ b/style.css
@@ -150,8 +150,8 @@ h6 {
 }
 
 .info-line .relation-particle {
-  display: inline-block;
-  font-weight: 400;
+  font-size: inherit;
+  font-weight: inherit;
 }
 
 .family-contact-section {
@@ -519,6 +519,7 @@ h6 {
   background: rgba(0, 0, 0, 0.5);
   justify-content: center;
   align-items: center;
+  flex-direction: column;
   z-index: 1000;
 }
 
@@ -536,23 +537,12 @@ h6 {
 .contact-content {
   position: relative;
   background: #fff;
-  padding: 0 32px 40px;
+  padding: 40px 32px;
   border-radius: 8px;
-  width: 90%;
+  width: calc(100% - 32px);
   max-width: 560px;
+  margin: 0 16px;
   text-align: left;
-}
-
-.contact-content .modal-close {
-  position: absolute;
-  top: 4px;
-  right: 8px;
-  margin-top: 0;
-  background: transparent;
-  border: none;
-  font-size: 1.5rem;
-  cursor: pointer;
-  color: #666;
 }
 
 .contact-image {


### PR DESCRIPTION
## Summary
- Float the contact modal with side margins, balanced padding, and a bottom close button to match the image modal
- Align relation particle styling with relation child and remove extra spacing before it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68957ae21a088327809752d0d253701f