### PR TITLE
Add aria labels to contact and map links for accessibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -91,8 +91,8 @@ const getTemplate = () => `
                 <span>${GROOM_NAME}</span>
               </span>
               <span class="contact-actions">
-                <a href="tel:${GROOM_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
-                <a href="sms:${GROOM_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
+                <a aria-label="${GROOM_NAME}에게 전화하기" href="tel:${GROOM_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
+                <a aria-label="${GROOM_NAME}에게 문자 보내기" href="sms:${GROOM_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
               </span>
             </li>
             <li>
@@ -101,8 +101,8 @@ const getTemplate = () => `
                 <span>${GROOM_FATHER}</span>
               </span>
               <span class="contact-actions">
-                <a href="tel:${GROOM_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
-                <a href="sms:${GROOM_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
+                <a aria-label="${GROOM_FATHER}에게 전화하기" href="tel:${GROOM_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
+                <a aria-label="${GROOM_FATHER}에게 문자 보내기" href="sms:${GROOM_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
               </span>
             </li>
             <li>
@@ -111,8 +111,8 @@ const getTemplate = () => `
                 <span>${GROOM_MOTHER}</span>
               </span>
               <span class="contact-actions">
-                <a href="tel:${GROOM_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
-                <a href="sms:${GROOM_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
+                <a aria-label="${GROOM_MOTHER}에게 전화하기" href="tel:${GROOM_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
+                <a aria-label="${GROOM_MOTHER}에게 문자 보내기" href="sms:${GROOM_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
               </span>
             </li>
             <li class="account">
@@ -133,8 +133,8 @@ const getTemplate = () => `
                 <span>${BRIDE_NAME}</span>
               </span>
               <span class="contact-actions">
-                <a href="tel:${BRIDE_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
-                <a href="sms:${BRIDE_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
+                <a aria-label="${BRIDE_NAME}에게 전화하기" href="tel:${BRIDE_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
+                <a aria-label="${BRIDE_NAME}에게 문자 보내기" href="sms:${BRIDE_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
               </span>
             </li>
             <li>
@@ -143,8 +143,8 @@ const getTemplate = () => `
                 <span>${BRIDE_FATHER}</span>
               </span>
               <span class="contact-actions">
-                <a href="tel:${BRIDE_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
-                <a href="sms:${BRIDE_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
+                <a aria-label="${BRIDE_FATHER}에게 전화하기" href="tel:${BRIDE_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
+                <a aria-label="${BRIDE_FATHER}에게 문자 보내기" href="sms:${BRIDE_FATHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
               </span>
             </li>
             <li>
@@ -153,8 +153,8 @@ const getTemplate = () => `
                 <span>${BRIDE_MOTHER}</span>
               </span>
               <span class="contact-actions">
-                <a href="tel:${BRIDE_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
-                <a href="sms:${BRIDE_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
+                <a aria-label="${BRIDE_MOTHER}에게 전화하기" href="tel:${BRIDE_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/phone.png" alt="전화" /></a>
+                <a aria-label="${BRIDE_MOTHER}에게 문자 보내기" href="sms:${BRIDE_MOTHER_PHONE.replace(/-/g, "")}"><img src="https://img.icons8.com/ios-glyphs/20/sms.png" alt="문자" /></a>
               </span>
             </li>
             <li class="account">
@@ -179,8 +179,8 @@ const getTemplate = () => `
     <p class="map-hall">${VENUE_HALL}</p>
     <div id="map" class="map-container"></div>
     <div class="map-buttons">
-      <a class="map-btn" href="https://map.naver.com/p/search/%EB%A9%94%EB%A6%AC%EB%B9%8C%EB%A6%AC%EC%95%84%EB%8D%94%ED%94%84%EB%A0%88%EC%8A%A4%ED%8B%B0%EC%A7%80/place/1856237237" target="_blank" rel="noopener noreferrer"><img src="https://play-lh.googleusercontent.com/iqe1hFI03eD6nW3S8fxK_MDvNC8tDtod_gnhF9e8XN-IPmLXJvZVJLm-bQ4U5mKAVK0" alt="네이버맵 아이콘" class="btn-icon" />네이버 지도</a>
-      <a class="map-btn" href="https://map.kakao.com/link/map/%EB%A9%94%EB%A6%AC%EB%B9%8C%EB%A6%AC%EC%95%84%EB%8D%94%ED%94%84%EB%A0%88%EC%8A%A4%ED%8B%B0%EC%A7%80,37.2627302,126.9966484" target="_blank" rel="noopener noreferrer"><img src="https://play-lh.googleusercontent.com/pPTTNz433EYFurg2j__bFU5ONdMoU_bs_-yS2JLZriua3iHrksGP6XBPF5VtDPlpGcW4" alt="카카오맵 아이콘" class="btn-icon" />카카오 지도</a>
+      <a aria-label="네이버 지도" class="map-btn" href="https://map.naver.com/p/search/%EB%A9%94%EB%A6%AC%EB%B9%8C%EB%A6%AC%EC%95%84%EB%8D%94%ED%94%84%EB%A0%88%EC%8A%A4%ED%8B%B0%EC%A7%80/place/1856237237" target="_blank" rel="noopener noreferrer"><img src="https://play-lh.googleusercontent.com/iqe1hFI03eD6nW3S8fxK_MDvNC8tDtod_gnhF9e8XN-IPmLXJvZVJLm-bQ4U5mKAVK0" alt="네이버맵 아이콘" class="btn-icon" />네이버 지도</a>
+      <a aria-label="카카오 지도" class="map-btn" href="https://map.kakao.com/link/map/%EB%A9%94%EB%A6%AC%EB%B9%8C%EB%A6%AC%EC%95%84%EB%8D%94%ED%94%84%EB%A0%88%EC%8A%A4%ED%8B%B0%EC%A7%80,37.2627302,126.9966484" target="_blank" rel="noopener noreferrer"><img src="https://play-lh.googleusercontent.com/pPTTNz433EYFurg2j__bFU5ONdMoU_bs_-yS2JLZriua3iHrksGP6XBPF5VtDPlpGcW4" alt="카카오맵 아이콘" class="btn-icon" />카카오 지도</a>
     </div>
     <div class="directions">
       <div class="direction-item walk">


### PR DESCRIPTION
## Summary
- add descriptive `aria-label` attributes to phone, SMS, and map links so screen readers announce their purpose
- include accessible names for all contact links and map buttons

## Testing
- `node -e "const fs = require('fs'); const {JSDOM} = require('jsdom'); const {computeAccessibleName} = require('dom-accessibility-api'); const vm = require('vm'); const dom = new JSDOM('<!DOCTYPE html><body></body>'); const sandbox = { window: dom.window, document: dom.window.document, navigator: dom.window.navigator, console }; vm.createContext(sandbox); const code = fs.readFileSync('script.js','utf8') + '\nthis.getTemplate = getTemplate;'; new vm.Script(code).runInContext(sandbox); const html = sandbox.getTemplate(); const dom2 = new JSDOM(html); dom2.window.document.querySelectorAll('a').forEach(a => { console.log(a.getAttribute('aria-label'), '->', computeAccessibleName(a)); });"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68957d4ea1248327bd8c2897f3de4234