### PR TITLE
feat: add dark theme and toggle

### DIFF
--- a/script.js
+++ b/script.js
@@ -37,6 +37,7 @@ const KAKAO_API_KEY =
   (window.env && window.env.KAKAO_API_KEY);
 
 const getTemplate = () => `
+  <button id="theme-toggle" class="theme-toggle">다크 모드</button>
   <section class="hero-section">
     <div class="hero-content">
       <div class="hero-names">
@@ -263,6 +264,26 @@ const loadExternalScript = (src) =>
 
 const init = async () => {
   document.body.innerHTML = getTemplate();
+  const savedTheme =
+    localStorage.getItem("theme") ||
+    (window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light");
+  document.documentElement.dataset.theme = savedTheme;
+  const themeToggle = document.getElementById("theme-toggle");
+  if (themeToggle) {
+    const updateToggle = (theme) => {
+      themeToggle.textContent = theme === "dark" ? "라이트 모드" : "다크 모드";
+    };
+    updateToggle(savedTheme);
+    themeToggle.addEventListener("click", () => {
+      const newTheme =
+        document.documentElement.dataset.theme === "dark" ? "light" : "dark";
+      document.documentElement.dataset.theme = newTheme;
+      localStorage.setItem("theme", newTheme);
+      updateToggle(newTheme);
+    });
+  }
   const eventDate = new Date(2026, 4, 17, 10, 30);
   const setDirectionInfo = (cls, info) => {
     const item = document.querySelector(`.map-section .${cls}`);

--- a/style.css
+++ b/style.css
@@ -8,6 +8,16 @@
   --highlight-color: #b22222;
 }
 
+[data-theme="dark"] {
+  --bg-color: #1a1a1a;
+  --text-color: #f5f5f5;
+  --secondary-bg-color: #2a2a2a;
+  --button-bg-color: #333333;
+  --button-text-color: #f5f5f5;
+  --button-hover-bg-color: #444444;
+  --highlight-color: #ff7f7f;
+}
+
 body {
   margin: 0;
   font-family: "Noto Sans KR", sans-serif;
@@ -488,6 +498,24 @@ h6 {
 }
 
 .contact-btn:hover {
+  background: var(--button-hover-bg-color);
+}
+
+.theme-toggle {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  padding: 8px 14px;
+  border: 1px solid #ddd;
+  border-radius: 20px;
+  background: var(--button-bg-color);
+  color: var(--button-text-color);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.theme-toggle:hover {
   background: var(--button-hover-bg-color);
 }
 


### PR DESCRIPTION
## Summary
- define dark theme CSS variables
- add theme toggle button with styling
- implement theme switching with saved preference

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68957d535bd88327946cd64c2bad5b93