### PR TITLE
Add hero section fade-in animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -263,6 +263,10 @@ const loadExternalScript = (src) =>
 
 const init = async () => {
   document.body.innerHTML = getTemplate();
+  const heroSection = document.querySelector(".hero-section");
+  if (heroSection) {
+    requestAnimationFrame(() => heroSection.classList.add("loaded"));
+  }
   const eventDate = new Date(2026, 4, 17, 10, 30);
   const setDirectionInfo = (cls, info) => {
     const item = document.querySelector(`.map-section .${cls}`);

--- a/style.css
+++ b/style.css
@@ -63,6 +63,14 @@ h6 {
   z-index: 1;
 }
 
+.hero-names,
+.hero-datetime,
+.hero-content .location,
+.hero-content .hall {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
 .hero-names {
   display: flex;
   flex-direction: column;
@@ -101,6 +109,36 @@ h6 {
   margin: 16px 0;
   font-size: 1.2rem;
   font-weight: 300;
+}
+
+.hero-section.loaded .hero-names {
+  animation: hero-fade-in 1.2s forwards;
+}
+
+.hero-section.loaded .hero-datetime {
+  animation: hero-fade-in 1.2s forwards;
+  animation-delay: 0.2s;
+}
+
+.hero-section.loaded .location {
+  animation: hero-fade-in 1.2s forwards;
+  animation-delay: 0.4s;
+}
+
+.hero-section.loaded .hall {
+  animation: hero-fade-in 1.2s forwards;
+  animation-delay: 0.6s;
+}
+
+@keyframes hero-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .invitation-section {


### PR DESCRIPTION
## Summary
- Animate hero names, date, and venue details with staged fade-in
- Trigger hero section animation after DOM load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895811fa7808327a37463417526f567