### PR TITLE
feat: adjust event-day color

### DIFF
--- a/style.css
+++ b/style.css
@@ -379,7 +379,7 @@ h6 {
   width: 32px;
   height: 32px;
   margin: 0 auto;
-  color: var(--highlight-color);
+  color: #fff;
   font-weight: 700;
   z-index: 0;
 }


### PR DESCRIPTION
## Summary
- use white text for calendar event-day cells

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895890cc150832790afc895abb19d2a