### PR TITLE
feat: add sequential animation utility

### DIFF
--- a/script.js
+++ b/script.js
@@ -39,37 +39,37 @@ const KAKAO_API_KEY =
 const getTemplate = () => `
   <section class="hero-section">
     <div class="hero-content">
-      <div class="hero-names">
+      <div class="hero-names sequential-item">
         <p class="groom">${GROOM_NAME}</p>
         <div class="name-separator"></div>
         <p class="bride">${BRIDE_NAME}</p>
       </div>
-      <p class="hero-datetime">${EVENT_DATETIME_TEXT}</p>
-      <p class="location">${VENUE_LOCATION}</p>
-      <p class="hall">${VENUE_HALL}</p>
+      <p class="hero-datetime sequential-item">${EVENT_DATETIME_TEXT}</p>
+      <p class="location sequential-item">${VENUE_LOCATION}</p>
+      <p class="hall sequential-item">${VENUE_HALL}</p>
     </div>
   </section>
 
   <section class="invitation-section fade-section">
-    <h2>초대의 글</h2>
-    <p>
+    <h2 class="sequential-item">초대의 글</h2>
+    <p class="sequential-item">
       꽃 향기 가득한 봄날, 서로를 존중하며 걸어온 두 사람이 한 자리에 서려 합니다.
     </p>
-    <p>
+    <p class="sequential-item">
       <strong>${EVENT_DATE_TEXT}</strong> 따뜻한 축복의 발걸음으로 함께해 주시면 큰 기쁨이 되겠습니다.
     </p>
   </section>
   <section class="family-contact-section fade-section">
-    <img src="https://picsum.photos/seed/wed0/600/400" alt="contact photo" class="contact-image" loading="eager" />
+    <img src="https://picsum.photos/seed/wed0/600/400" alt="contact photo" class="contact-image sequential-item" loading="eager" />
     <div class="family-section">
-        <p class="info-line">
+        <p class="info-line sequential-item">
           <span class="info-name parent-name">${GROOM_FATHER}</span>
           <span class="name-dot">·</span>
           <span class="info-name parent-name">${GROOM_MOTHER}</span><span class="relation-particle">의</span>
           <span class="relation-child">아들</span>
           <span class="info-name child-name">${GROOM_FIRST_NAME}</span>
         </p>
-        <p class="info-line">
+        <p class="info-line sequential-item">
           <span class="info-name parent-name">${BRIDE_FATHER}</span>
           <span class="name-dot">·</span>
           <span class="info-name parent-name">${BRIDE_MOTHER}</span><span class="relation-particle">의</span>
@@ -77,7 +77,7 @@ const getTemplate = () => `
           <span class="info-name child-name">${BRIDE_FIRST_NAME}</span>
         </p>
     </div>
-    <button id="contact-btn" class="contact-btn">연락하기</button>
+    <button id="contact-btn" class="contact-btn sequential-item">연락하기</button>
   </section>
 
   <div id="contact-modal" class="contact-modal">
@@ -261,26 +261,49 @@ const loadExternalScript = (src) =>
     document.head.appendChild(s);
   });
 
+const applySequentialAnimation = (containerSelector) => {
+  const container = document.querySelector(containerSelector);
+  if (!container) return;
+  const items = container.querySelectorAll(".sequential-item");
+  items.forEach((el, index) => {
+    el.style.setProperty("--delay", `${index * 0.2}s`);
+  });
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    container.classList.add("loaded");
+    return;
+  }
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("loaded");
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.3 },
+  );
+  observer.observe(container);
+};
+
 const init = async () => {
   document.body.innerHTML = getTemplate();
   const prefersReducedMotion = window.matchMedia(
     "(prefers-reduced-motion: reduce)",
   ).matches;
+  applySequentialAnimation(".hero-section");
+  applySequentialAnimation(".invitation-section");
+  applySequentialAnimation(".family-contact-section");
   const heroSection = document.querySelector(".hero-section");
-  if (heroSection) {
-    if (prefersReducedMotion) {
-      heroSection.classList.add("loaded");
-    } else {
-      requestAnimationFrame(() => heroSection.classList.add("loaded"));
-      const createPetal = () => {
-        const petal = document.createElement("span");
-        petal.className = "petal";
-        petal.style.left = `${Math.random() * 100}%`;
-        heroSection.appendChild(petal);
-        petal.addEventListener("animationend", () => petal.remove());
-      };
-      setInterval(createPetal, 1000);
-    }
+  if (heroSection && !prefersReducedMotion) {
+    const createPetal = () => {
+      const petal = document.createElement("span");
+      petal.className = "petal";
+      petal.style.left = `${Math.random() * 100}%`;
+      heroSection.appendChild(petal);
+      petal.addEventListener("animationend", () => petal.remove());
+    };
+    setInterval(createPetal, 1000);
   }
   const eventDate = new Date(2026, 4, 17, 10, 30);
   const setDirectionInfo = (cls, info) => {

--- a/style.css
+++ b/style.css
@@ -35,6 +35,27 @@ h6 {
   font-weight: 400;
 }
 
+.sequential-item {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+.loaded .sequential-item {
+  animation: sequential-fade-in 1.2s forwards;
+  animation-delay: var(--delay);
+}
+
+@keyframes sequential-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .hero-section {
   display: flex;
   align-items: center;
@@ -61,14 +82,6 @@ h6 {
 .hero-content {
   position: relative;
   z-index: 1;
-}
-
-.hero-names,
-.hero-datetime,
-.hero-content .location,
-.hero-content .hall {
-  opacity: 0;
-  transform: translateY(20px);
 }
 
 .hero-names {
@@ -109,36 +122,6 @@ h6 {
   margin: 16px 0;
   font-size: 1.2rem;
   font-weight: 300;
-}
-
-.hero-section.loaded .hero-names {
-  animation: hero-fade-in 1.2s forwards;
-}
-
-.hero-section.loaded .hero-datetime {
-  animation: hero-fade-in 1.2s forwards;
-  animation-delay: 0.2s;
-}
-
-.hero-section.loaded .location {
-  animation: hero-fade-in 1.2s forwards;
-  animation-delay: 0.4s;
-}
-
-.hero-section.loaded .hall {
-  animation: hero-fade-in 1.2s forwards;
-  animation-delay: 0.6s;
-}
-
-@keyframes hero-fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
 }
 
 .invitation-section {


### PR DESCRIPTION
## Summary
- add reusable `.sequential-item` and `sequential-fade-in` keyframes
- create `applySequentialAnimation` helper to delay and reveal items on scroll
- apply sequential animations to hero, invitation, and family contact sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68958c63fd8c8327b513e0eef4dfdfcb