### PR TITLE
Refine map view and hero animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -328,8 +328,20 @@ const init = async () => {
       );
       const position = new naver.maps.LatLng(VENUE_LAT, VENUE_LNG);
       const map = new naver.maps.Map("map", {
-        center: position,
-        zoom: 15,
+        center: new naver.maps.LatLng(
+          VENUE_LAT + 0.0025,
+          VENUE_LNG + 0.003,
+        ),
+        zoom: 17,
+        minZoom: 17,
+        maxZoom: 17,
+        zoomControl: false,
+        scrollWheel: false,
+        disableDoubleTapZoom: true,
+        disableDoubleClickZoom: true,
+        disableTwoFingerTapZoom: true,
+        pinchZoom: false,
+        keyboardShortcuts: false,
       });
       const marker = new naver.maps.Marker({ position, map });
       const infoWindow = new naver.maps.InfoWindow({

--- a/style.css
+++ b/style.css
@@ -80,7 +80,7 @@ h6 {
 }
 
 .hero-section.hero-zoom {
-  animation: hero-zoom 10s ease-out forwards;
+  animation: hero-zoom 5s ease-out forwards;
 }
 
 @keyframes hero-zoom {


### PR DESCRIPTION
## Summary
- Recenter venue map so the marker sits bottom-left, showing Suwon Station and disabling zoom interactions.
- Speed up initial hero background animation for a snappier intro.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a15c009c832795c8d4d876a330ac