### PR TITLE
Support four-row gallery display

### DIFF
--- a/script.js
+++ b/script.js
@@ -492,7 +492,7 @@ const init = async () => {
     const cols = getComputedStyle(galleryGrid)
       .getPropertyValue("grid-template-columns")
       .split(" ").length;
-    const initialVisible = cols === 2 ? 8 : 9; // 필요한 경우 다른 규칙 적용
+    const initialVisible = Math.min(cols * 4, images.length);
 
     images.forEach((src, idx) => {
       const img = document.createElement("img");
@@ -511,6 +511,10 @@ const init = async () => {
       slide.appendChild(slideImg);
       swiperWrapper.appendChild(slide);
     });
+
+    if (images.length <= initialVisible) {
+      moreBtn.style.display = "none";
+    }
 
     const closeGallery = () => {
       modal.classList.remove("open");


### PR DESCRIPTION
## Summary
- show up to four rows of images in main gallery
- hide the "more" button when all images are visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a19b358483278a76cdf9f36fc68d