### PR TITLE
fix: improve hero and map layout on wide screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -69,6 +69,13 @@ h6 {
   overflow: hidden;
 }
 
+@media screen and (min-aspect-ratio: 3/2) {
+  .hero-section {
+    background-size: contain;
+    background-position: center;
+  }
+}
+
 .hero-section::before {
   content: "";
   position: absolute;
@@ -296,6 +303,8 @@ h6 {
   background: #eaeaea;
   border-radius: 16px;
   overflow: hidden;
+  max-width: 600px;
+  margin: 0 auto;
 }
 
 .map-buttons {


### PR DESCRIPTION
## Summary
- prevent hero image from cropping on landscape/wide screens
- limit map width to avoid horizontal stretching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895b05a205483278732d41bbf06eb4c