### PR TITLE
Disable dragging on directions map

### DIFF
--- a/script.js
+++ b/script.js
@@ -338,6 +338,7 @@ const init = async () => {
         maxZoom: 16,
         zoomControl: false,
         scrollWheel: false,
+        draggable: false,
         disableDoubleTapZoom: true,
         disableDoubleClickZoom: true,
         disableTwoFingerTapZoom: true,


### PR DESCRIPTION
## Summary
- prevent panning on the map in the directions section by setting `draggable: false`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895b4818f5483278eaa03e75482a4ad