### PR TITLE
fix: show gallery image previews

### DIFF
--- a/script.js
+++ b/script.js
@@ -61,7 +61,12 @@ const getTemplate = () => `
     </p>
   </section>
   <section class="family-contact-section fade-section">
-    <img src="https://picsum.photos/seed/wed0/600/400" alt="contact photo" class="contact-image floating sequential-item" loading="eager" />
+    <img
+      src="https://picsum.photos/seed/wed0/600/400"
+      alt="contact photo"
+      class="contact-image floating sequential-item"
+      loading="eager"
+    />
     <div class="family-section">
         <p class="info-line sequential-item">
           <span class="info-name parent-name">${GROOM_FATHER}</span>
@@ -544,7 +549,7 @@ const init = async () => {
       img.src = src;
       img.alt = `gallery image ${idx + 1}`;
       img.className = "gallery-image floating";
-      img.loading = "lazy";
+      img.loading = idx < initialVisible ? "eager" : "lazy";
       img.decoding = "async";
       img.width = 600;
       img.height = 400;


### PR DESCRIPTION
## Summary
- load initial gallery images eagerly so previews appear immediately
- keep other gallery images lazily loaded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895c0c8e5fc8327a2ef8e93786c961e