### PR TITLE
fix: correct gallery modal image width

### DIFF
--- a/script.js
+++ b/script.js
@@ -548,6 +548,7 @@ const init = async () => {
       document.body.classList.add("no-scroll");
       initSwiper();
       if (swiper) {
+        swiper.update();
         swiper.slideTo(idx, 0);
       }
     };


### PR DESCRIPTION
## Summary
- ensure gallery modal updates Swiper before sliding to prevent clipped images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aa37b042c83278e08f5b9ecf15b11