### PR TITLE
fix: center modal swiper images

### DIFF
--- a/style.css
+++ b/style.css
@@ -519,6 +519,8 @@ h6 {
   align-items: center;
 }
 .image-modal .swiper-slide img {
+  display: block;
+  margin: 0 auto;
   max-width: 100%;
   max-height: 80vh;
   width: auto;


### PR DESCRIPTION
## Summary
- ensure images within gallery modal swiper are centered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689aab9bc2088327b0204e8948a35759