### PR TITLE
fix: keep hero fixed and overlay sections

### DIFF
--- a/style.css
+++ b/style.css
@@ -68,8 +68,12 @@ h6 {
     center/cover no-repeat;
   background-color: #fff;
   color: #fff;
-  position: relative;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
   overflow: hidden;
+  z-index: 0;
 }
 
 @media screen and (min-aspect-ratio: 3/2) {
@@ -91,6 +95,16 @@ h6 {
 
 .hero-section.hero-zoom {
   animation: hero-zoom 3s ease-out forwards;
+}
+
+section:not(.hero-section) {
+  position: relative;
+  z-index: 1;
+  background: var(--bg-color);
+}
+
+.invitation-section {
+  margin-top: 100vh;
 }
 
 @keyframes hero-zoom {


### PR DESCRIPTION
## Summary
- fix hero section with fixed positioning so it stays put
- allow other sections to scroll above the hero and start below it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689abaa262cc8327966d3b12b7cf1b25