### PR TITLE
Rename T맵 button and hide on desktop

### DIFF
--- a/script.js
+++ b/script.js
@@ -187,7 +187,7 @@ const getTemplate = () => `
     <div class="map-buttons">
       <a aria-label="네이버 지도" class="map-btn floating" href="https://map.naver.com/p/search/%EB%A9%94%EB%A6%AC%EB%B9%8C%EB%A6%AC%EC%95%84%EB%8D%94%ED%94%84%EB%A0%88%EC%8A%A4%ED%8B%B0%EC%A7%80/place/1856237237" target="_blank" rel="noopener noreferrer"><img src="https://play-lh.googleusercontent.com/iqe1hFI03eD6nW3S8fxK_MDvNC8tDtod_gnhF9e8XN-IPmLXJvZVJLm-bQ4U5mKAVK0" alt="네이버맵 아이콘" class="btn-icon" />네이버 지도</a>
       <a aria-label="카카오 지도" class="map-btn floating" href="https://map.kakao.com/link/map/%EB%A9%94%EB%A6%AC%EB%B9%8C%EB%A6%AC%EC%95%84%EB%8D%94%ED%94%84%EB%A0%88%EC%8A%A4%ED%8B%B0%EC%A7%80,37.2627302,126.9966484" target="_blank" rel="noopener noreferrer"><img src="https://play-lh.googleusercontent.com/pPTTNz433EYFurg2j__bFU5ONdMoU_bs_-yS2JLZriua3iHrksGP6XBPF5VtDPlpGcW4" alt="카카오맵 아이콘" class="btn-icon" />카카오 지도</a>
-      <a aria-label="T맵" class="map-btn floating" href="tmap://route?goalx=126.9966484&goaly=37.2627302&goalname=%EB%A9%94%EB%A6%AC%EB%B9%8C%EB%A6%AC%EC%95%84%EB%8D%94%ED%94%84%EB%A0%88%EC%8A%A4%ED%8B%B0%EC%A7%80" target="_blank" rel="noopener noreferrer"><img src="https://play-lh.googleusercontent.com/WcrqQ9atNdC7dp4vG4fWue0kRdMxiDSTKu9E1Zj7EmGcgdQ8j3u9_2Tt8vw-zPvKCkg" alt="티맵 아이콘" class="btn-icon" />T맵 지도</a>
+      <a aria-label="티맵" class="map-btn floating" href="tmap://route?goalx=126.9966484&goaly=37.2627302&goalname=%EB%A9%94%EB%A6%AC%EB%B9%8C%EB%A6%AC%EC%95%84%EB%8D%94%ED%94%84%EB%A0%88%EC%8A%A4%ED%8B%B0%EC%A7%80" target="_blank" rel="noopener noreferrer"><img src="https://play-lh.googleusercontent.com/WcrqQ9atNdC7dp4vG4fWue0kRdMxiDSTKu9E1Zj7EmGcgdQ8j3u9_2Tt8vw-zPvKCkg" alt="티맵 아이콘" class="btn-icon" />티맵 지도</a>
     </div>
     <div class="directions">
       <div class="direction-item walk">
@@ -645,9 +645,13 @@ const init = async () => {
   });
 
   const shareSection = document.querySelector(".share-section");
+  const tmapBtn = document.querySelector('.map-btn[aria-label="티맵"]');
   const isMobile = /Mobi|Android/i.test(navigator.userAgent);
   if (shareSection && !isMobile) {
     shareSection.style.display = "none";
+  }
+  if (tmapBtn && !isMobile) {
+    tmapBtn.style.display = "none";
   }
 
   const fadeSections = document.querySelectorAll(".fade-section");


### PR DESCRIPTION
## Summary
- rename `T맵 지도` button to `티맵 지도`
- hide 티맵 link when visiting from a desktop browser

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689abe13d7048327a9ea6948174242c3