### PR TITLE
Darken glass sections on scroll for readability

### DIFF
--- a/script.js
+++ b/script.js
@@ -670,6 +670,14 @@ const init = async () => {
     );
     fadeSections.forEach((sec) => observer.observe(sec));
   }
+
+  let scrolled = false;
+  window.addEventListener("scroll", () => {
+    if (!scrolled && window.scrollY > 0) {
+      document.body.classList.add("scrolled");
+      scrolled = true;
+    }
+  });
 };
 
 if (document.readyState === "loading") {

--- a/style.css
+++ b/style.css
@@ -104,6 +104,15 @@ h6 {
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
 }
+
+.scrolled .glass-section {
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  --text-color: #fff;
+  --button-bg-color: rgba(255, 255, 255, 0.2);
+  --button-text-color: #fff;
+  --button-hover-bg-color: rgba(255, 255, 255, 0.3);
+}
 @keyframes hero-zoom {
   from {
     transform: scale(1);


### PR DESCRIPTION
## Summary
- darken glass section background and switch text to white after the page is scrolled
- add scroll listener to apply new style when user begins scrolling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ac2797228832795c6f1020fb0e9dd