### PR TITLE
Make glass sections display white text

### DIFF
--- a/style.css
+++ b/style.css
@@ -851,3 +851,16 @@ h6 {
   }
 }
 
+/* White text in glass sections */
+.glass-section,
+.glass-section * {
+  color: #fff;
+}
+
+/* Exclude calendar and map markers from white text */
+.glass-section #calendar,
+.glass-section #calendar *,
+.glass-section #map,
+.glass-section #map * {
+  color: initial;
+}


### PR DESCRIPTION
## Summary
- ensure all glass-section text renders white
- keep calendar and map markers in their default colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ac66b7b60832785322baa28979a88