### PR TITLE
Restore hero brightness when scrolling up

### DIFF
--- a/script.js
+++ b/script.js
@@ -671,18 +671,20 @@ const init = async () => {
     fadeSections.forEach((sec) => observer.observe(sec));
   }
 
-  let scrolled = false;
   const invitationSection = document.querySelector(".invitation-section");
   const triggerOffset =
     invitationSection
       ? invitationSection.offsetTop - window.innerHeight + 80
       : 80;
-  window.addEventListener("scroll", () => {
-    if (!scrolled && window.scrollY > triggerOffset) {
+  const updateHeroScroll = () => {
+    if (window.scrollY > triggerOffset) {
       document.body.classList.add("scrolled");
-      scrolled = true;
+    } else {
+      document.body.classList.remove("scrolled");
     }
-  });
+  };
+  window.addEventListener("scroll", updateHeroScroll);
+  updateHeroScroll();
 };
 
 if (document.readyState === "loading") {


### PR DESCRIPTION
## Summary
- Adjust scroll handler to toggle `scrolled` class based on scroll position so the hero section brightens when scrolling back above the trigger offset.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689acb9928288327b00ea506675317b7