### PR TITLE
Enable dynamic liquid glass refraction

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,24 @@
     </script>
   </head>
   <body>
+    <svg aria-hidden="true" focusable="false" style="display: none">
+      <filter id="liquid-glass">
+        <feTurbulence
+          type="fractalNoise"
+          baseFrequency="0.02"
+          numOctaves="2"
+          result="noise"
+        >
+          <animate
+            attributeName="baseFrequency"
+            dur="20s"
+            values="0.02;0.05;0.02"
+            repeatCount="indefinite"
+          />
+        </feTurbulence>
+        <feDisplacementMap in="SourceGraphic" in2="noise" scale="30" />
+      </filter>
+    </svg>
     <script
       src="https://t1.kakaocdn.net/kakao_js_sdk/2.4.0/kakao.min.js"
       crossorigin="anonymous"

--- a/style.css
+++ b/style.css
@@ -112,9 +112,10 @@ h6 {
   content: "";
   position: absolute;
   inset: -5%;
-  background: var(--hero-image) center/cover fixed;
-  transform: scale(1.05);
-  filter: blur(10px);
+  background: rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(15px);
+  -webkit-backdrop-filter: blur(15px);
+  filter: url("#liquid-glass");
   z-index: -2;
 }
 


### PR DESCRIPTION
## Summary
- Add animated SVG filter for liquid glass refraction and apply it to glass sections
- Use backdrop-filter and animated displacement for real-time distortion of hero background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689acc80c388832788f377febfcf09b3