### PR TITLE
feat: increase transparency of glass section

### DIFF
--- a/style.css
+++ b/style.css
@@ -112,7 +112,7 @@ h6 {
   content: "";
   position: absolute;
   inset: -5%;
-  background: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(15px);
   -webkit-backdrop-filter: blur(15px);
   filter: url("#liquid-glass");
@@ -124,9 +124,9 @@ h6 {
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(135deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0) 70%) top left/50% 50% no-repeat,
-    linear-gradient(225deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0) 70%) top right/50% 50% no-repeat,
-    rgba(255, 255, 255, 0.3);
+    linear-gradient(135deg, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0) 70%) top left/50% 50% no-repeat,
+    linear-gradient(225deg, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0) 70%) top right/50% 50% no-repeat,
+    rgba(255, 255, 255, 0.1);
   pointer-events: none;
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- soften liquid glass overlay by reducing base white alpha to 0.05
- lighten highlight gradients and overlay tint for a more transparent effect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689acda4453883279e0922a91a44df3d