### PR TITLE
Darken hero section on scroll and lighten glass overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -96,7 +96,7 @@ h6 {
 }
 
 .scrolled .hero-section::before {
-  background: rgba(0, 0, 0, 0.7);
+  background: rgba(0, 0, 0, 0.85);
 }
 
 .hero-section.hero-zoom {
@@ -112,7 +112,7 @@ h6 {
   content: "";
   position: absolute;
   inset: -5%;
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.03);
   backdrop-filter: blur(15px);
   -webkit-backdrop-filter: blur(15px);
   filter: url("#liquid-glass");
@@ -124,9 +124,9 @@ h6 {
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(135deg, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0) 70%) top left/50% 50% no-repeat,
-    linear-gradient(225deg, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0) 70%) top right/50% 50% no-repeat,
-    rgba(255, 255, 255, 0.1);
+    linear-gradient(135deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0) 70%) top left/50% 50% no-repeat,
+    linear-gradient(225deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0) 70%) top right/50% 50% no-repeat,
+    rgba(255, 255, 255, 0.05);
   pointer-events: none;
   z-index: -1;
 }


### PR DESCRIPTION
## Summary
- Darken hero overlay when page scrolls to emphasize content
- Increase transparency of liquid glass sections for lighter aesthetic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ad01e736083278262d07038339cce