### PR TITLE
Trigger scroll animations earlier and faster

### DIFF
--- a/script.js
+++ b/script.js
@@ -289,7 +289,7 @@ const applySequentialAnimation = (containerSelector) => {
         }
       });
     },
-    { threshold: 0.3 },
+    { threshold: 0.1 },
   );
   observer.observe(container);
 };
@@ -670,7 +670,7 @@ const init = async () => {
           }
         });
       },
-      { threshold: 0.5 },
+      { threshold: 0.2 },
     );
     fadeSections.forEach((sec) => observer.observe(sec));
   }

--- a/style.css
+++ b/style.css
@@ -45,7 +45,7 @@ h6 {
 }
 
 .loaded .sequential-item {
-  animation: sequential-fade-in 0.8s forwards;
+  animation: sequential-fade-in 0.6s forwards;
   animation-delay: var(--delay);
 }
 
@@ -858,7 +858,7 @@ h6 {
 .fade-section {
   opacity: 0;
   transform: translateY(40px) scale(0.95);
-  transition: opacity 0.8s ease-out, transform 0.8s ease-out;
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
 }
 
 .fade-section.visible {


### PR DESCRIPTION
## Summary
- Reveal sections with a lower IntersectionObserver threshold for earlier scroll animations
- Speed up fade-in animations by shortening CSS transition durations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689addb17f90832788e4f79e5ba87a82