### PR TITLE
Set normal weight for countdown completion strong

### DIFF
--- a/style.css
+++ b/style.css
@@ -343,6 +343,10 @@ h6 {
   color: #666;
 }
 
+.countdown-intro strong {
+  font-weight: 400;
+}
+
 .count-thin {
   font-weight: 300;
 }


### PR DESCRIPTION
## Summary
- Ensure strong elements in the countdown completion message use normal font weight

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689adddc50348327b7a3e1379186acb3