### PR TITLE
Set text colors for glass elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -898,15 +898,18 @@ h6 {
   }
 }
 
-/* White text in glass sections and buttons */
+/* Text colors for glass sections and buttons */
 .glass-section,
-.glass-section *,
+.glass-section * {
+  color: #fff;
+}
+
 .glass-button,
 .glass-button * {
   color: #000;
 }
 
-/* Exclude calendar and map markers from glass-button text color */
+/* Exclude calendar and map markers from glass-section text color */
 .glass-section #calendar,
 .glass-section #calendar *,
 .glass-section #map,


### PR DESCRIPTION
## Summary
- Make `.glass-section` use white text and `.glass-button` use black text for better contrast
- Adjust comment to match updated behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ae49c825083278220a5f7d05b5c14