### PR TITLE
Fix hero scroll issue due to animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -312,7 +312,9 @@ const init = async () => {
   if (heroSection && !prefersReducedMotion) {
     heroSection.classList.add("hero-zoom");
     const finishHero = () => {
-      heroSection.getAnimations().forEach((anim) => anim.finish());
+      heroSection.getAnimations().forEach((anim) => anim.cancel());
+      heroSection.classList.remove("hero-zoom");
+      heroSection.style.removeProperty("transform");
     };
     window.addEventListener("scroll", finishHero, { once: true });
   }


### PR DESCRIPTION
## Summary
- Cancel hero animation and remove transform on first scroll to prevent oversized hero from covering subsequent sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ae47c0e2c8327b95b84db6e65bd23