### PR TITLE
Fix share button text and icons

### DIFF
--- a/script.js
+++ b/script.js
@@ -231,14 +231,14 @@ const getTemplate = () => `
     <div class="share-row">
         <button id="copy-url" class="floating glass-button">
         <img
-          src="https://img.icons8.com/ios-glyphs/30/FFFFFF/copy.png"
+          src="https://img.icons8.com/ios-glyphs/30/000000/copy.png"
           alt="복사 아이콘"
           class="btn-icon"
         />URL 복사
       </button>
         <button id="share-url" class="floating glass-button">
         <img
-          src="https://img.icons8.com/ios-glyphs/30/FFFFFF/share.png"
+          src="https://img.icons8.com/ios-glyphs/30/000000/share.png"
           alt="공유 아이콘"
           class="btn-icon"
         />URL 공유

--- a/style.css
+++ b/style.css
@@ -572,7 +572,6 @@ h6 {
   border: 1px solid #ddd;
   border-radius: 20px;
   background: var(--button-bg-color);
-  color: var(--button-text-color);
   cursor: pointer;
   transition: background 0.2s ease;
 }
@@ -658,7 +657,6 @@ h6 {
   border: 1px solid #ddd;
   border-radius: 20px;
   background: var(--button-bg-color);
-  color: var(--button-text-color);
   font-size: 1rem;
   cursor: pointer;
   transition: background 0.2s ease;


### PR DESCRIPTION
## Summary
- Remove hardcoded white text color from gallery and share buttons
- Use black icons for URL copy and share buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ae5dc41c883278d7f284eee17baa4