### PR TITLE
Animate calendar heart on press

### DIFF
--- a/script.js
+++ b/script.js
@@ -382,6 +382,17 @@ const init = async () => {
     }
     html += "</tr></tbody></table>";
     calendarEl.innerHTML = html;
+    const eventDayEl = calendarEl.querySelector(".event-day");
+    if (eventDayEl) {
+      const activate = () => eventDayEl.classList.add("heart-active");
+      const deactivate = () => eventDayEl.classList.remove("heart-active");
+      calendarEl.addEventListener("mousedown", activate);
+      calendarEl.addEventListener("touchstart", activate);
+      calendarEl.addEventListener("mouseup", deactivate);
+      calendarEl.addEventListener("mouseleave", deactivate);
+      calendarEl.addEventListener("touchend", deactivate);
+      calendarEl.addEventListener("touchcancel", deactivate);
+    }
   }
 
   const countdownEl = document.getElementById("countdown");

--- a/style.css
+++ b/style.css
@@ -500,10 +500,15 @@ h6 {
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%) scale(1);
   font-size: 32px;
   color: #f0e6f6;
   z-index: -1;
+  transition: transform 0.2s;
+}
+
+.calendar-container .event-day.heart-active::before {
+  transform: translate(-50%, -50%) scale(1.2);
 }
 
 #countdown {


### PR DESCRIPTION
## Summary
- animate calendar heart when pressing the schedule calendar
- add JS listeners to toggle heart scale on press and release

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b01c75f848327836ca6524d31cfaf