### PR TITLE
Add loading overlay spinner

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,9 @@
     </script>
   </head>
   <body>
+    <div id="loading-overlay" class="loading-section">
+      <div class="spinner"></div>
+    </div>
     <script
       src="https://t1.kakaocdn.net/kakao_js_sdk/2.4.0/kakao.min.js"
       crossorigin="anonymous"

--- a/script.js
+++ b/script.js
@@ -754,7 +754,11 @@ const init = async () => {
 };
 
 if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", init);
+  document.addEventListener("DOMContentLoaded", () => {
+    init();
+    document.body.classList.add("loaded");
+  });
 } else {
   init();
+  document.body.classList.add("loaded");
 }

--- a/style.css
+++ b/style.css
@@ -30,6 +30,39 @@ body.no-scroll {
   overflow: hidden;
 }
 
+.loading-section {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--hero-image) center/cover no-repeat;
+  background-color: #fff;
+  z-index: 1000;
+}
+
+.loading-section .spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid rgba(255, 255, 255, 0.5);
+  border-top-color: var(--highlight-color);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+body.loaded .loading-section {
+  display: none;
+}
+
 h2,
 h3,
 h4,
@@ -879,6 +912,10 @@ h6 {
   .copy-account img {
     animation: none;
     transition: none;
+  }
+
+  .loading-section .spinner {
+    animation: none;
   }
 
   .hero-names,


### PR DESCRIPTION
## Summary
- Add full-screen loading overlay with spinner hidden after initialization
- Style loading overlay to match hero imagery and support reduced-motion preferences
- Signal script completion by toggling `loaded` class on body

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c15b64e5c83278540d78573aa25a7