### PR TITLE
Add timed loading overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
       document.getElementById("main-style").href = `style.css${window.CACHE_BUSTER}`;
     </script>
   </head>
-  <body>
+  <body class="loading">
     <div id="loading-overlay" class="loading-section">
       <div class="spinner"></div>
     </div>

--- a/script.js
+++ b/script.js
@@ -753,12 +753,18 @@ const init = async () => {
   updateHeroScroll();
 };
 
+const finishLoading = () => {
+  document.body.classList.add("loaded");
+  document.body.classList.remove("loading");
+  window.scrollTo(0, 90);
+};
+
 if (document.readyState === "loading") {
   document.addEventListener("DOMContentLoaded", () => {
     init();
-    document.body.classList.add("loaded");
+    setTimeout(finishLoading, 1500);
   });
 } else {
   init();
-  document.body.classList.add("loaded");
+  setTimeout(finishLoading, 1500);
 }

--- a/style.css
+++ b/style.css
@@ -30,6 +30,15 @@ body.no-scroll {
   overflow: hidden;
 }
 
+body.loading {
+  overflow: hidden;
+  pointer-events: none;
+}
+
+body.loading * {
+  pointer-events: none;
+}
+
 .loading-section {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- show loading overlay for the first 1.5 seconds
- block pointer and scroll input while loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c1d1089a8832787deb8a2a0b7e2c9