### PR TITLE
Improve loading screen and scroll animation timing

### DIFF
--- a/script.js
+++ b/script.js
@@ -731,7 +731,7 @@ const init = async () => {
           }
         });
       },
-      { threshold: 0.2 },
+      { threshold: 0.1 },
     );
     fadeSections.forEach((sec) => observer.observe(sec));
   }
@@ -760,11 +760,11 @@ const finishLoading = () => {
 };
 
 if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", () => {
-    init();
-    setTimeout(finishLoading, 1500);
-  });
+  document.addEventListener("DOMContentLoaded", init);
 } else {
   init();
-  setTimeout(finishLoading, 1500);
 }
+
+window.addEventListener("load", () => {
+  setTimeout(finishLoading, 1500);
+});

--- a/style.css
+++ b/style.css
@@ -51,6 +51,8 @@ body.loading * {
   background: var(--hero-image) center/cover no-repeat;
   background-color: #fff;
   z-index: 1000;
+  opacity: 1;
+  transition: opacity 0.3s ease;
 }
 
 .loading-section .spinner {
@@ -69,7 +71,8 @@ body.loading * {
 }
 
 body.loaded .loading-section {
-  display: none;
+  opacity: 0;
+  pointer-events: none;
 }
 
 h2,
@@ -917,6 +920,7 @@ h6 {
   .hero-content .hall,
   .fade-section,
   .fade-section.visible,
+  .loading-section,
   .contact-actions img,
   .copy-account img {
     animation: none;


### PR DESCRIPTION
## Summary
- ensure loading overlay remains visible until window load and fades out smoothly
- trigger section fade-in animations earlier during scroll

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c1f3395988327969137ea2e163489