### PR TITLE
Prevent interaction before content loads

### DIFF
--- a/script.js
+++ b/script.js
@@ -753,7 +753,24 @@ const init = async () => {
   updateHeroScroll();
 };
 
+const blockEvent = (e) => e.preventDefault();
+
+const disableInteraction = () => {
+  window.addEventListener("wheel", blockEvent, { passive: false });
+  window.addEventListener("touchmove", blockEvent, { passive: false });
+  window.addEventListener("keydown", blockEvent, true);
+};
+
+const enableInteraction = () => {
+  window.removeEventListener("wheel", blockEvent, { passive: false });
+  window.removeEventListener("touchmove", blockEvent, { passive: false });
+  window.removeEventListener("keydown", blockEvent, true);
+};
+
+disableInteraction();
+
 const finishLoading = () => {
+  enableInteraction();
   document.body.classList.add("loaded");
   document.body.classList.remove("loading");
   window.scrollTo(0, 90);

--- a/style.css
+++ b/style.css
@@ -33,6 +33,8 @@ body.no-scroll {
 body.loading {
   overflow: hidden;
   pointer-events: none;
+  touch-action: none;
+  overscroll-behavior: none;
 }
 
 body.loading * {


### PR DESCRIPTION
## Summary
- Block wheel, touchmove, and keydown events until the page is fully loaded
- Disable scrolling and overscroll while loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c23e080648327856e6abbd5f4f74b