### PR TITLE
Run initial scroll before loading overlay

### DIFF
--- a/script.js
+++ b/script.js
@@ -749,7 +749,6 @@ const init = async () => {
     }
   };
   window.addEventListener("scroll", updateHeroScroll);
-  window.scrollTo(0, 90);
   updateHeroScroll();
 };
 
@@ -767,13 +766,13 @@ const enableInteraction = () => {
   window.removeEventListener("keydown", blockEvent, true);
 };
 
+window.scrollTo(0, 90);
 disableInteraction();
 
 const finishLoading = () => {
   enableInteraction();
   document.body.classList.add("loaded");
   document.body.classList.remove("loading");
-  window.scrollTo(0, 90);
 };
 
 const MIN_LOADING_TIME = 1500;


### PR DESCRIPTION
## Summary
- Trigger initial scroll offset immediately on script load
- Keep loading overlay visible until `loaded` class is applied

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c25df797883279b10462990c745db