### PR TITLE
Replace window load with DOMContentLoaded for loading state

### DIFF
--- a/script.js
+++ b/script.js
@@ -778,20 +778,15 @@ const finishLoading = () => {
 const MIN_LOADING_TIME = 1500;
 const loadStart = performance.now();
 
-const onWindowLoad = () => {
+const onDomContentLoaded = async () => {
+  await init();
   const elapsed = performance.now() - loadStart;
   const delay = Math.max(MIN_LOADING_TIME - elapsed, 0);
   setTimeout(finishLoading, delay);
 };
 
 if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", init);
+  document.addEventListener("DOMContentLoaded", onDomContentLoaded);
 } else {
-  init();
-}
-
-if (document.readyState === "complete") {
-  onWindowLoad();
-} else {
-  window.addEventListener("load", onWindowLoad);
+  onDomContentLoaded();
 }


### PR DESCRIPTION
## Summary
- replace window load event with DOMContentLoaded to toggle `loading` to `loaded`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c29540be0832791383b4048cad8ca