### PR TITLE
Increase hero content opacity transition duration

### DIFF
--- a/style.css
+++ b/style.css
@@ -192,7 +192,7 @@ h6 {
   position: relative;
   z-index: 1;
   color: #fff;
-  transition: color 0.3s, opacity 0.5s;
+  transition: color 0.3s, opacity 2s;
 }
 
 .scrolled .hero-content {


### PR DESCRIPTION
## Summary
- Slow down hero content fade transition for a smoother effect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c2d6f2e2c8327939792dcab8324b0