### PR TITLE
Disable tap highlight and prevent touchstart default

### DIFF
--- a/script.js
+++ b/script.js
@@ -387,7 +387,10 @@ const init = async () => {
       const activate = () => eventDayEl.classList.add("heart-active");
       const deactivate = () => eventDayEl.classList.remove("heart-active");
       calendarEl.addEventListener("mousedown", activate);
-      calendarEl.addEventListener("touchstart", activate);
+      calendarEl.addEventListener("touchstart", (e) => {
+        e.preventDefault();
+        activate();
+      });
       calendarEl.addEventListener("mouseup", deactivate);
       calendarEl.addEventListener("mouseleave", deactivate);
       calendarEl.addEventListener("touchend", deactivate);

--- a/style.css
+++ b/style.css
@@ -491,6 +491,11 @@ h6 {
   box-sizing: border-box;
 }
 
+#calendar,
+#calendar * {
+  -webkit-tap-highlight-color: transparent;
+}
+
 .calendar-header {
   font-size: 1.2rem;
   font-weight: 400;


### PR DESCRIPTION
## Summary
- remove tap highlight from calendar elements
- prevent default touchstart to trigger heart animation without mobile highlight

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c34b1958c8327a258e0a60ac962bd