### PR TITLE
style: unify glass-button appearance

### DIFF
--- a/style.css
+++ b/style.css
@@ -173,14 +173,14 @@ h6 {
   position: relative;
   z-index: 1;
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.75) !important;
-  border: 1px solid rgba(255, 255, 255, 0.9) !important;
+  background: rgba(255, 255, 255, 0.85) !important;
+  border: 1px solid rgba(255, 255, 255, 0.95) !important;
 }
 
 .glass-button::before {
   content: "";
   position: absolute;
-  background: rgba(255, 255, 255, 0.75);
+  background: rgba(255, 255, 255, 0.85);
   backdrop-filter: blur(15px);
   -webkit-backdrop-filter: blur(15px);
   border-radius: inherit;
@@ -965,6 +965,8 @@ h6 {
 .glass-button,
 .glass-button * {
   color: #000;
+  font-size: 1rem;
+  font-weight: 400;
 }
 
 /* Exclude calendar and map markers from glass-section text color */


### PR DESCRIPTION
## Summary
- standardize glass-button text color, size, and weight
- adjust glass-button background and border opacity for clarity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c35b785288327a486d802d13e98a8