### PR TITLE
Limit press-scale effect to buttons and images

### DIFF
--- a/script.js
+++ b/script.js
@@ -306,16 +306,10 @@ const applySequentialAnimation = (containerSelector) => {
 
 const init = async () => {
   document.body.innerHTML = getTemplate();
-  const pressables = document.querySelectorAll(
-    "section:not(.hero-section), button",
-  );
+  const pressables = document.querySelectorAll("button, img");
   pressables.forEach((el) => {
-    const target =
-      el.matches("section") && el.querySelector(".section-content")
-        ? el.querySelector(".section-content")
-        : el;
-    const add = () => target.classList.add("press-scale");
-    const remove = () => target.classList.remove("press-scale");
+    const add = () => el.classList.add("press-scale");
+    const remove = () => el.classList.remove("press-scale");
     el.addEventListener("mousedown", add);
     el.addEventListener("touchstart", add);
     el.addEventListener("mouseup", remove);

--- a/style.css
+++ b/style.css
@@ -561,14 +561,13 @@ h6 {
   transform: translate(-50%, -50%) scale(2);
 }
 
-section:not(.hero-section),
-section:not(.hero-section) .section-content,
-button {
+button,
+img {
   transition: transform 0.2s;
 }
 
 .press-scale {
-  transform: scale(1.2);
+  transform: scale(1.1);
 }
 
 #countdown {


### PR DESCRIPTION
## Summary
- Reduce press-scale transform from 1.2 to 1.1 and apply only to buttons and images
- Limit press-scale event listeners to buttons and images to avoid scaling text or sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c3cb7b5788327bb9d866d369b1193