### PR TITLE
Adjust scaling interaction and fix copy toast visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -563,11 +563,12 @@ h6 {
 
 button,
 img {
-  transition: transform 0.2s;
+  transition: transform 0.2s, scale 0.2s;
 }
 
 .press-scale {
-  transform: scale(1.1);
+  transform: scale(1.2);
+  scale: 1.2;
 }
 
 #countdown {
@@ -753,6 +754,7 @@ img {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.3s ease;
+  z-index: 1100;
 }
 
 .copy-toast.show {


### PR DESCRIPTION
## Summary
- Increase press-scale animation to 1.2 and support scale transitions
- Add high z-index to copy toast so it stays visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c4357e24c83279517f965573dff66