### PR TITLE
Remove gallery modal scale animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -590,7 +590,6 @@ const init = async () => {
     const images = await getGalleryImages();
     const moreBtn = document.getElementById("gallery-more");
     const modal = document.getElementById("image-modal");
-    const modalContent = document.getElementById("modal-swiper");
     const swiperWrapper = document.getElementById("modal-swiper-wrapper");
     const closeBtn = document.getElementById("modal-close");
     let swiper;
@@ -607,18 +606,7 @@ const init = async () => {
       }
     };
 
-    const openModal = (idx, trigger) => {
-      if (trigger && modalContent) {
-        const rect = trigger.getBoundingClientRect();
-        const modalWidth = modalContent.offsetWidth;
-        const modalHeight = modalContent.offsetHeight;
-        const originX =
-          rect.left + rect.width / 2 - (window.innerWidth - modalWidth) / 2;
-        const originY =
-          rect.top + rect.height / 2 - (window.innerHeight - modalHeight) / 2;
-        modalContent.style.setProperty("--origin-x", `${originX}px`);
-        modalContent.style.setProperty("--origin-y", `${originY}px`);
-      }
+    const openModal = (idx) => {
       modal.classList.add("open");
       document.body.classList.add("no-scroll");
       initSwiper();
@@ -646,11 +634,11 @@ const init = async () => {
       img.decoding = "async";
       img.tabIndex = 0;
       if (idx >= initialVisible) img.classList.add("hidden");
-      img.addEventListener("click", (e) => openModal(idx, e.currentTarget));
+      img.addEventListener("click", () => openModal(idx));
       img.addEventListener("keydown", (e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          openModal(idx, img);
+          openModal(idx);
         }
       });
       galleryGrid.appendChild(img);

--- a/style.css
+++ b/style.css
@@ -662,13 +662,6 @@ a {
   max-width: 600px;
   padding: 0 16px;
   box-sizing: border-box;
-  transform: scale(0);
-  transform-origin: var(--origin-x) var(--origin-y);
-  transition: transform 0.3s ease;
-}
-
-.image-modal.open .swiper {
-  transform: scale(1);
 }
 
 .image-modal .swiper-slide {


### PR DESCRIPTION
## Summary
- Remove scale animation from gallery modal so images open without scaling effect.
- Simplify gallery modal JS event handling.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c5012663c8327b2cbe14de9b1f534