### PR TITLE
Remove press-scale from modal swiper images

### DIFF
--- a/script.js
+++ b/script.js
@@ -662,7 +662,7 @@ const init = async () => {
       slideImg.loading = "lazy";
       slideImg.decoding = "async";
       slide.appendChild(slideImg);
-      makePressable(slideImg);
+      // gallery modal images should not scale on press
       swiperWrapper.appendChild(slide);
     });
 


### PR DESCRIPTION
## Summary
- Prevent press-scale effect on images inside gallery modal swiper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c525ea1508327a995c0004d198d98