### PR TITLE
feat: replace press-scale with brightness effect

### DIFF
--- a/style.css
+++ b/style.css
@@ -564,12 +564,11 @@ h6 {
 button,
 img,
 a {
-  transition: transform 0.2s, scale 0.2s;
+  transition: filter 0.2s, transform 0.2s;
 }
 
 .press-scale {
-  transform: scale(1.2);
-  scale: 1.2;
+  filter: brightness(1.1);
 }
 
 #countdown {


### PR DESCRIPTION
## Summary
- brighten press-scale targets instead of scaling
- keep calendar heart scaling untouched

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c54e6491c8327ba53a6ccb036ed82