### PR TITLE
Rename press-scale utility to press-brighten

### DIFF
--- a/script.js
+++ b/script.js
@@ -305,8 +305,8 @@ const applySequentialAnimation = (containerSelector) => {
 };
 
 const makePressable = (el) => {
-  const add = () => el.classList.add("press-scale");
-  const remove = () => el.classList.remove("press-scale");
+  const add = () => el.classList.add("press-brighten");
+  const remove = () => el.classList.remove("press-brighten");
   el.addEventListener("mousedown", add);
   el.addEventListener("touchstart", add);
   el.addEventListener("mouseup", remove);

--- a/style.css
+++ b/style.css
@@ -567,8 +567,8 @@ a {
   transition: filter 0.2s, transform 0.2s;
 }
 
-.press-scale {
-  filter: brightness(1.1);
+.press-brighten {
+  filter: brightness(1.3);
 }
 
 #countdown {


### PR DESCRIPTION
## Summary
- increase pressed element brightness to 1.3
- rename `press-scale` class and related code to `press-brighten`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c5657e2d48327abdb4b66f0d7aac2