### PR TITLE
Avoid persistent highlight on long press

### DIFF
--- a/script.js
+++ b/script.js
@@ -305,14 +305,23 @@ const applySequentialAnimation = (containerSelector) => {
 };
 
 const makePressable = (el) => {
-  const add = () => el.classList.add("press-brighten");
-  const remove = () => el.classList.remove("press-brighten");
+  let pressTimer;
+  const add = () => {
+    el.classList.add("press-brighten");
+    clearTimeout(pressTimer);
+    pressTimer = setTimeout(() => el.classList.remove("press-brighten"), 200);
+  };
+  const remove = () => {
+    clearTimeout(pressTimer);
+    el.classList.remove("press-brighten");
+  };
   el.addEventListener("mousedown", add);
   el.addEventListener("touchstart", add);
   el.addEventListener("mouseup", remove);
   el.addEventListener("mouseleave", remove);
   el.addEventListener("touchend", remove);
   el.addEventListener("touchcancel", remove);
+  el.addEventListener("contextmenu", remove);
   const delay = (e) => {
     e.preventDefault();
     e.stopImmediatePropagation();


### PR DESCRIPTION
## Summary
- remove press-brighten after delay so long presses don't stay highlighted
## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c599025108327932ce6bf9a964073