### PR TITLE
Call resize on init

### DIFF
--- a/hero-3d.js
+++ b/hero-3d.js
@@ -43,6 +43,7 @@ export function initHero3D() {
     renderer.setSize(container.clientWidth, container.clientHeight);
   };
   window.addEventListener("resize", resize);
+  resize();
 
   let frameId;
   const animate = () => {


### PR DESCRIPTION
## Summary
- ensure hero 3D canvas initializes to correct size by invoking `resize()` once on setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d3fb233608327ad08145022f127e4