### PR TITLE
Increase particle size in hero animation

### DIFF
--- a/hero-3d.js
+++ b/hero-3d.js
@@ -33,7 +33,7 @@ export function initHero3D() {
     "position",
     new THREE.Float32BufferAttribute(vertices, 3),
   );
-  const material = new THREE.PointsMaterial({ color: 0xff6699, size: 0.05 });
+  const material = new THREE.PointsMaterial({ color: 0xff6699, size: 0.1 });
   const particles = new THREE.Points(geometry, material);
   scene.add(particles);
 


### PR DESCRIPTION
## Summary
- make hero particles larger for better visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d3fb3cee8832786633186feece70b