### PR TITLE
Add global 3D text effect

### DIFF
--- a/script.js
+++ b/script.js
@@ -337,6 +337,7 @@ const makePressable = (el) => {
 
 const init = async () => {
   document.body.innerHTML = getTemplate();
+  document.body.classList.add("text-3d");
   const pressables = document.querySelectorAll("button, a, img");
   pressables.forEach((el) => {
     if (el.tagName === "IMG" && el.closest("a")) return;

--- a/style.css
+++ b/style.css
@@ -49,6 +49,24 @@ body.loaded .hero-content {
   opacity: 1;
 }
 
+.text-3d,
+.text-3d * {
+  text-shadow:
+    1px 1px 0 rgba(0, 0, 0, 0.2),
+    2px 2px 0 rgba(0, 0, 0, 0.15),
+    3px 3px 0 rgba(0, 0, 0, 0.1);
+  background: repeating-linear-gradient(
+    45deg,
+    #fff,
+    #fff 10px,
+    #f0f0f0 10px,
+    #f0f0f0 20px
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
 .loading-section {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- add `.text-3d` class with layered shadows and gradient-filled text for a 3D look
- enable the effect across the site by adding the class to `<body>` during initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d4d37d04c8327bd1402a32e293530